### PR TITLE
Delete AUTHORS file

### DIFF
--- a/flux-kube/AUTHORS
+++ b/flux-kube/AUTHORS
@@ -1,3 +1,0 @@
-Dong Ahn
-Stephen Herbein
-Daniel Milroy


### PR DESCRIPTION
This single-commit PR deletes the AUTHORS file that snuck back in upon rebasing PR #9 before the merge.