### PR TITLE
Flux-Kube translation library

### DIFF
--- a/flux-kube/Makefile.am
+++ b/flux-kube/Makefile.am
@@ -1,3 +1,3 @@
 ACLOCAL_AMFLAGS = -I config
 
-SUBDIRS = cmd
+SUBDIRS = cmd lib

--- a/flux-kube/configure.ac
+++ b/flux-kube/configure.ac
@@ -10,7 +10,6 @@ AC_CONFIG_SRCDIR([NEWS])
 
 AM_INIT_AUTOMAKE([subdir-objects tar-ustar filename-length-max=256 foreign])
 AM_SILENT_RULES([yes])
-# AM_CONFIG_HEADER([config.h])
 AM_MAINTAINER_MODE([enable])
 
 AC_PREFIX_PROGRAM([flux])
@@ -42,7 +41,8 @@ AC_SUBST(fluxcmddir)
 # Tells automake to create a Makefile
 # See https://www.gnu.org/software/automake/manual/html_node/Requirements.html
 AC_CONFIG_FILES([Makefile
-  cmd/Makefile])
+  cmd/Makefile
+  lib/Makefile])
 
 # Generate the output
 AC_OUTPUT

--- a/flux-kube/lib/Makefile.am
+++ b/flux-kube/lib/Makefile.am
@@ -1,0 +1,2 @@
+dist_fluxcmd_SCRIPTS = \
+	kube_translator.py

--- a/flux-kube/lib/kube_translator.py
+++ b/flux-kube/lib/kube_translator.py
@@ -1,0 +1,83 @@
+##############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import warnings
+
+
+class JobspecTranslator:
+    """
+    JobspecTranslator is a base class for mapping and translating
+    a jobspec with template overrides into a Kubernetes
+    or OpenShift template.
+    """
+
+    def __init__(self, jobspec_dict, templates_dict):
+        """
+        args:
+             jobspec_dict is the YAML jobspec ingested as a dict
+             templates_dict is a dictionary keyed by the cluster
+                  service template names, with values of the templates
+                  themselves
+        """
+        self.jobspec = jobspec_dict
+        self.templates = templates_dict
+
+        # Check for multiple services per jobspec, which is
+        # currently unsupported.
+        if len(self.jobspec["tasks"]) > 1:
+            raise NotImplementedError(
+                "Requesting multiple services per " "jobspec is currently unsupported\n"
+            )
+
+        if len(self.jobspec["tasks"][0]["command"]) > 1:
+            raise NotImplementedError(
+                "Requesting multiple services per " "jobspec is currently unsupported\n"
+            )
+
+        # Check if the service name requested matches a known template
+        try:
+            self.service = {
+                "template": self.templates[(self.jobspec["tasks"][0]["command"][0])]
+            }
+        except KeyError:
+            print(
+                "service %s not a registered template on the cluster\n"
+                % self.jobspec["tasks"][0]["command"]
+            )
+            raise
+
+    def translate(self):
+        if "template_overrides" in self.jobspec["attributes"]["system"]:
+            param_names = set()
+            self.service["overrides"] = {}
+            for override in self.jobspec["attributes"]["system"]["template_overrides"]:
+                matched = False
+                for param in self.service["template"]["parameters"]:
+                    if override in param_names:
+                        (self.service["overrides"][override]) = self.jobspec[
+                            "attributes"
+                        ]["system"]["template_overrides"][override]
+                        matched = True
+                    else:
+                        if param["name"] not in param_names:
+                            param_names.update([param["name"]])
+                        if param["name"] == override:
+                            (self.service["overrides"][override]) = self.jobspec[
+                                "attributes"
+                            ]["system"]["template_overrides"][override]
+                            matched = True
+                if not matched:
+                    warnings.warn(
+                        "Warning: specified overrides do not match "
+                        "template parameters\n",
+                        SyntaxWarning,
+                    )
+
+            return self.service


### PR DESCRIPTION
This PR adds the functionality of mapping a Flux jobspec to an OpenShift template.  The library takes a Flux jobspec and matches the jobspec `command` to a corresponding OpenShift template name.  It then matches the template parameter overrides specified in the jobspec's system attributes to the overrides available in the selected template.  The library returns a `service`, which is the selected template with the dictionary of parameter overrides.