### PR TITLE
Flux-Kube jobtap plugin

### DIFF
--- a/flux-kube/Makefile.am
+++ b/flux-kube/Makefile.am
@@ -1,3 +1,3 @@
 ACLOCAL_AMFLAGS = -I config
 
-SUBDIRS = cmd lib
+SUBDIRS = cmd lib plugins

--- a/flux-kube/Makefile.am
+++ b/flux-kube/Makefile.am
@@ -1,3 +1,3 @@
 ACLOCAL_AMFLAGS = -I config
 
-SUBDIRS = cmd
+SUBDIRS = cmd lib

--- a/flux-kube/configure.ac
+++ b/flux-kube/configure.ac
@@ -14,8 +14,19 @@ AM_MAINTAINER_MODE([enable])
 
 AC_PREFIX_PROGRAM([flux])
 
-# Check for C compiler
-# AC_PROG_CC
+LT_INIT([dlopen])
+
+PKG_PROG_PKG_CONFIG
+
+# Checks for programs.
+AC_DEFINE([_GNU_SOURCE], 1,
+          [Define _GNU_SOURCE so that we get all necessary prototypes])
+AC_PROG_CC
+AC_PROG_CC_C99
+AC_PROG_LN_S
+AC_PROG_MAKE_SET
+AM_PROG_CC_C_O
+
 # We can add more checks in this section
 AX_FLUX_CORE
 
@@ -38,11 +49,21 @@ AM_CHECK_PYMOD(openshift,
 AS_VAR_SET(fluxcmddir, $libexecdir/flux/cmd)
 AC_SUBST(fluxcmddir)
 
+AS_VAR_SET(jobtap_plugindir, $libdir/flux/job-manager/plugins)
+AC_SUBST(jobtap_plugindir)
+
+##
+# Macros to avoid repetition in Makefiles.am's
+##
+fluxplugin_ldflags="-avoid-version -export-symbols-regex '^flux_plugin_init\$\$' --disable-static -shared -export-dynamic -module"
+AC_SUBST(fluxplugin_ldflags)
+
 # Tells automake to create a Makefile
 # See https://www.gnu.org/software/automake/manual/html_node/Requirements.html
 AC_CONFIG_FILES([Makefile
   cmd/Makefile
-  lib/Makefile])
+  lib/Makefile
+  plugins/Makefile])
 
 # Generate the output
 AC_OUTPUT

--- a/flux-kube/configure.ac
+++ b/flux-kube/configure.ac
@@ -10,7 +10,6 @@ AC_CONFIG_SRCDIR([NEWS])
 
 AM_INIT_AUTOMAKE([subdir-objects tar-ustar filename-length-max=256 foreign])
 AM_SILENT_RULES([yes])
-# AM_CONFIG_HEADER([config.h])
 AM_MAINTAINER_MODE([enable])
 
 AC_PREFIX_PROGRAM([flux])
@@ -42,7 +41,8 @@ AC_SUBST(fluxcmddir)
 # Tells automake to create a Makefile
 # See https://www.gnu.org/software/automake/manual/html_node/Requirements.html
 AC_CONFIG_FILES([Makefile
-  cmd/Makefile])
+  cmd/Makefile
+  lib/Makefile])
 
 # Generate the output
 AC_OUTPUT

--- a/flux-kube/lib/Makefile.am
+++ b/flux-kube/lib/Makefile.am
@@ -1,0 +1,2 @@
+dist_fluxcmd_SCRIPTS = \
+	kube_translator.py

--- a/flux-kube/lib/kube_translator.py
+++ b/flux-kube/lib/kube_translator.py
@@ -1,0 +1,82 @@
+##############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import warnings
+
+class JobspecTranslator:
+    """
+    JobspecTranslator is a base class for mapping and translating 
+    a jobspec with template overrides into a Kubernetes 
+    or OpenShift template.
+    """
+    
+    def __init__(self, jobspec_dict, templates_dict):
+        """
+        args: 
+             jobspec_dict is the YAML jobspec ingested as a dict
+             templates_dict is a dictionary keyed by the cluster 
+                  service template names, with values of the templates 
+                  themselves
+        """
+        self.jobspec = jobspec_dict
+        self.templates = templates_dict
+
+        # Check for multiple services per jobspec, which is 
+        # currently unsupported.
+        if len(self.jobspec['tasks']) > 1:
+            raise NotImplementedError("Requesting multiple services per "
+                                      "jobspec is currently unsupported\n")
+
+        if len(self.jobspec['tasks'][0]['command']) > 1:
+            raise NotImplementedError("Requesting multiple services per "
+                                      "jobspec is currently unsupported\n")
+
+        # Check if the service name requested matches a known template
+        try:
+            self.service = {'template': self.templates[(self.jobspec['tasks']
+                                                       [0]
+                                                       ['command']
+                                                       [0])]}
+        except KeyError:
+            print("service %s not a registered template on the cluster\n" 
+                  % self.jobspec['tasks'][0]['command'])
+            raise
+        
+    def translate(self):
+        if 'template_overrides' in self.jobspec['attributes']['system']:
+            param_names = set()
+            self.service['overrides'] = {}
+            for override in (self.jobspec['attributes']
+                                         ['system']
+                                         ['template_overrides']):
+                matched = False
+                for param in self.service['template']['parameters']:
+                    if override in param_names:
+                        (self.service['overrides']
+                                     [override]) = (self.jobspec['attributes']
+                                                                ['system']
+                                                                ['template_overrides']
+                                                                [override])
+                        matched = True
+                    else:
+                        if param['name'] not in param_names:
+                            param_names.update([param['name']])
+                        if param['name'] == override:
+                            (self.service['overrides']
+                                         [override]) = (self.jobspec['attributes']
+                                                            ['system']
+                                                            ['template_overrides']
+                                                            [override])
+                            matched = True
+                if not matched:
+                    warnings.warn("Warning: specified overrides do not match "
+                                  "template parameters\n", SyntaxWarning)
+
+            return self.service

--- a/flux-kube/plugins/Makefile.am
+++ b/flux-kube/plugins/Makefile.am
@@ -1,0 +1,18 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) 
+
+AM_CPPFLAGS = \
+	-I$(FLUX_PREFIX) \
+	-I$(FLUX_PREFIX)/src/include \
+	-I$(FLUX_PREFIX)/src/common/libflux \
+	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
+
+jobtap_plugin_LTLIBRARIES = \
+	flux-kube.la
+
+flux_kube_la_SOURCES = \
+	flux-kube.c
+
+flux_kube_la_LDFLAGS = \
+	$(fluxplugin_ldflags) \
+	-module

--- a/flux-kube/plugins/flux-kube.c
+++ b/flux-kube/plugins/flux-kube.c
@@ -1,0 +1,284 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* flux-kube.c - If attributes.system.R exists in jobspec, then
+ *  bypass scheduler alloc protocol and use R directly (for instance
+ *  owner use only)
+ */
+
+#include <unistd.h>
+#include <sys/types.h>
+
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+static void alloc_continuation (flux_future_t *f, void *arg)
+{
+    flux_plugin_t *p = arg;
+    flux_jobid_t *idptr = flux_future_aux_get (f, "jobid");
+
+    if (flux_future_get (f, NULL) < 0) {
+        flux_jobtap_raise_exception (p,
+                                     *idptr,
+                                     "alloc", 0,
+                                     "failed to commit R to kvs: %s",
+                                      strerror (errno));
+        goto done;
+    }
+    if (flux_jobtap_event_post_pack (p,
+                                     *idptr,
+                                     "alloc",
+                                     "{s:b}",
+                                     "bypass", true) < 0)
+        flux_jobtap_raise_exception (p,
+                                     *idptr,
+                                     "alloc", 0,
+                                     "failed to post alloc event: %s",
+                                     strerror (errno));
+
+    /*  Set "needs-free" so that flux-kube knows that a "free"
+     *  event needs to be emitted for this node.
+     */
+    if (flux_jobtap_job_aux_set (p, *idptr, "flux-kube::free", p, NULL) < 0)
+        flux_log_error (flux_jobtap_get_flux (p),
+                        "id=%ju: Failed to set flux-kube::free",
+                        *idptr);
+
+done:
+    flux_future_destroy (f);
+}
+
+static int alloc_start (flux_plugin_t *p,
+                        flux_jobid_t id,
+                        const char *R)
+{
+    flux_t *h;
+    char key[64];
+    flux_future_t *f = NULL;
+    flux_kvs_txn_t *txn = NULL;
+    flux_jobid_t *idptr = NULL;
+
+    if (!(h = flux_jobtap_get_flux (p))
+        || flux_job_kvs_key (key, sizeof (key), id, "R") < 0
+        || !(txn = flux_kvs_txn_create ())
+        || flux_kvs_txn_put (txn, 0, key, R) < 0
+        || !(f = flux_kvs_commit (h, NULL, 0, txn))
+        || flux_future_then (f, -1, alloc_continuation, p)
+        || !(idptr = calloc (1, sizeof (*idptr)))
+        || flux_future_aux_set (f, "jobid", idptr, free) < 0) {
+        flux_kvs_txn_destroy (txn);
+        flux_future_destroy (f);
+        free (idptr);
+        return -1;
+    }
+    *idptr = id;
+    flux_kvs_txn_destroy (txn);
+    return 0;
+}
+
+
+static int sched_cb (flux_plugin_t *p,
+                     const char *topic,
+                     flux_plugin_arg_t *args,
+                     void *arg)
+{
+    const char *R, *jobspec = NULL;
+    flux_jobid_t id;
+    flux_future_t *f;
+    int retval = -1;
+
+    /*  If flux-kube::R set on this job then commit R to KVS,
+     *  get the jobspec, submit the jobspec to flux-kube.py, 
+     *  and set flux-kube flag.
+     */
+    if (!(R = flux_jobtap_job_aux_get (p,
+                                       FLUX_JOBTAP_CURRENT_JOB,
+                                       "flux-kube::R")))
+        return 0;
+
+    if (!(jobspec = flux_jobtap_job_aux_get (p,
+                                       FLUX_JOBTAP_CURRENT_JOB,
+                                       "flux-kube::jobspec")))
+        return 0;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I}",
+                                "id", &id) < 0) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "flux-kube: %s: unpack: %s",
+                                     topic,
+                                     flux_plugin_arg_strerror (args));
+        return -1;
+    }
+
+    if (!(f = flux_rpc_pack (flux_jobtap_get_flux (p), "fluxkube.submit", 
+                             FLUX_NODEID_ANY, 0,
+                             "{s:s}", "jobspec", jobspec))) { 
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "flux-kube: %s: Failed to send RPC: %s",
+                                     topic,
+                                     strerror (errno));
+        return -1;
+    }
+    
+    if (flux_rpc_get_unpack (f, "{s:i}", "retval", &retval) != 0) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "flux-kube: %s: Failed to "
+                                     "unpack RPC: %s",
+                                     topic,
+                                     strerror (errno));
+        return -1;
+    }
+
+    if (retval != 0) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "flux-kube.py: %s: submit callback "
+                                     "failed: %s",
+                                     topic,
+                                     strerror (errno));
+        return -1;
+    }
+
+    if (alloc_start (p, id, R) < 0)
+        flux_jobtap_raise_exception (p, id, "alloc", 0,
+                                     "failed to commit R to kvs");
+
+    if (flux_jobtap_job_set_flag (p,
+                                  FLUX_JOBTAP_CURRENT_JOB,
+                                  "alloc-bypass") < 0)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                            "alloc", 0,
+                                            "Failed to set alloc-bypass: %s",
+                                            strerror (errno));
+    return 0;
+}
+
+static int cleanup_cb (flux_plugin_t *p,
+                       const char *topic,
+                       flux_plugin_arg_t *args,
+                       void *arg)
+{
+    /*  If flux-kube::free is set on this job, then this plugin
+     *   sent an "alloc" event, so a "free" event needs to be sent now.
+     */
+    if (flux_jobtap_job_aux_get (p,
+                                 FLUX_JOBTAP_CURRENT_JOB,
+                                 "flux-kube::free")) {
+        if (flux_jobtap_event_post_pack (p,
+                                         FLUX_JOBTAP_CURRENT_JOB,
+                                         "free",
+                                         NULL) < 0)
+             flux_log_error (flux_jobtap_get_flux (p),
+                             "flux-kube: failed to post free event");
+    }
+    return 0;
+}
+
+static int validate_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *arg)
+{
+    int fluxkube = 0;
+    json_t *jobspec = NULL;
+    char *js, *s;
+    uint32_t userid = (uint32_t) -1;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:i s:{s:{s:{s?i}}}}",
+                                "userid", &userid,
+                                "jobspec",
+                                 "attributes",
+                                  "system",
+                                   "flux-kube", &fluxkube) < 0) {
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "invalid system.flux-kube: %s",
+                                       flux_plugin_arg_strerror (args));
+    }
+
+    /*  Nothing to do if not fluxkube
+     */
+    if (!fluxkube)
+        return 0;
+
+    if (userid != getuid ())
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "Guest user cannot use alloc bypass");
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:o}",
+                                "jobspec", &jobspec) < 0) {
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "invalid jobspec: %s",
+                                       flux_plugin_arg_strerror (args));
+    }
+   /*  Store jobspec in job structure to avoid re-fetching from plugin args
+     *   in job.state.sched callback.
+     */
+    if (!(js = json_dumps (jobspec, 0))
+        || flux_jobtap_job_aux_set (p,
+                                    FLUX_JOBTAP_CURRENT_JOB,
+                                    "flux-kube::jobspec",
+                                    js,
+                                    free) < 0) {
+        free (js);
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "failed to capture flux-kube "
+                                       "jobspec: %s",
+                                       strerror (errno));
+    }
+    /*  Store R string in job structure to avoid re-fetching from plugin args
+     *   in job.state.sched callback.
+     */
+    s = "{\"version\": 1, "
+          "\"execution\": "
+            "{\"R_lite\": "
+              "[{\"rank\": \"0\", "
+                "\"children\": "
+                  "{\"core\": \"0\"}}], "
+              "\"starttime\": 0.0, "
+              "\"expiration\": 0.0, "
+              "\"nodelist\": "
+              "[\"kubernetes\"]}}";
+    if (flux_jobtap_job_aux_set (p,
+                                 FLUX_JOBTAP_CURRENT_JOB,
+                                 "flux-kube::R", 
+                                 strdup (s), 
+                                 free) < 0)
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "failed to capture flux-kube R: %s",
+                                       strerror (errno));
+    return 0;
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.state.sched",   sched_cb,    NULL },
+    { "job.state.cleanup", cleanup_cb,  NULL },
+    { "job.validate",      validate_cb, NULL },
+    { 0 }
+};
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    return flux_plugin_register (p, "flux-kube", tab);
+}


### PR DESCRIPTION
This PR adds the `flux-kube.so` jobtap plugin and the associated machinery to build and install it.  The jobtap plugin is based on alloc-bypass.so (flux-core 90461710f1f09ed48cc7586abff5cb4fee6dc63d). The plugin looks for attributes.system.flux-kube set in the jobspec. If it's present, the plugin sets the "alloc-bypass" flag, passes the jobspec to flux-kube.py via RPC, and unpacks the response. Then the plugin generates a dummy R (since the resources will reside on OpenShift) and commits it to the KVS. Finally, the plugin emits an "alloc" event.

This PR depends on PR #11 and can only be merged after it.