### PR TITLE
Flux-Kube CLI and daemon

### DIFF
--- a/flux-kube/Makefile.am
+++ b/flux-kube/Makefile.am
@@ -1,3 +1,3 @@
 ACLOCAL_AMFLAGS = -I config
 
-SUBDIRS = cmd lib plugins
+SUBDIRS = cmd lib plugins etc

--- a/flux-kube/Makefile.am
+++ b/flux-kube/Makefile.am
@@ -1,3 +1,3 @@
 ACLOCAL_AMFLAGS = -I config
 
-SUBDIRS = cmd lib
+SUBDIRS = cmd lib plugins

--- a/flux-kube/Makefile.am
+++ b/flux-kube/Makefile.am
@@ -1,3 +1,3 @@
 ACLOCAL_AMFLAGS = -I config
 
-SUBDIRS = cmd
+SUBDIRS = cmd lib

--- a/flux-kube/cmd/flux-kube.py
+++ b/flux-kube/cmd/flux-kube.py
@@ -1,5 +1,5 @@
 ##############################################################
-# Copyright 2020 Lawrence Livermore National Security, LLC
+# Copyright 2021 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)
 #
 # This file is part of the Flux resource manager framework.
@@ -10,31 +10,32 @@
 
 import logging
 import argparse
+import urllib3
+import yaml
+import subprocess
+import errno
 
+from kube_translator import JobspecTranslator
 from kubernetes import client, config
 from openshift.dynamic import DynamicClient
 
+import flux
 from flux import util
+from flux.constants import FLUX_MSGTYPE_REQUEST
 
 
 class KubeCmd:
     """
-    KubeCmd is the base class for all flux-kube subcommands
+    KubeCmd is the base class for all flux-kube subcommands. 
+    While all derived classes interface with K8s and OpenShift, 
+    much of the functionality requires OpenShift templates. 
+    The functionality will be extended to interface with 
+    base K8s CRDs (which can replicate the template functionality) 
+    in the future.
     """
 
     def __init__(self, **kwargs):
         self.parser = self.create_parser()
-
-        k8s_client = config.new_client_from_config()
-        try:
-            self.dyn_client = DynamicClient(k8s_client)
-        except client.rest.ApiException as rest_exception:
-            if rest_exception.status == 403:
-                raise Exception(
-                    "You must be logged in to the K8s or OpenShift"
-                    " cluster to continue"
-                )
-            raise
 
     @staticmethod
     def create_parser():
@@ -49,43 +50,353 @@ class KubeCmd:
         return self.parser
 
 
-class GetDeploymentsCmd(KubeCmd):
+class InitKube(KubeCmd):
     """
-    GetDeploymentsCmd gets all the user's
-    deployments in the specified namespace
-    and prints all their attributes.
+    InitKube initializes Kube/Openshift
     """
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
 
         self.parser.add_argument(
             "-n",
             "--namespace",
             type=str,
+            default="openshift",
             metavar="N",
-            help="Namespace of deployment",
+            help="OpenShift/K8s namespace",
+        )
+        k8s_client = config.new_client_from_config()
+        try:
+            dyn_client = DynamicClient(k8s_client)
+        except client.rest.ApiException as rest_exception:
+            if rest_exception.status == 401:
+                raise Exception(
+                    "You must be logged in to the K8s or OpenShift"
+                    " cluster to continue"
+                )
+            raise
+        self.dyn_client = dyn_client
+
+    def main(self, args):
+        try:
+            template = self.dyn_client.resources.get(
+                api_version="template.openshift.io/v1", kind="Template"
+            )
+            templates = template.get(namespace=args.namespace)
+        except client.rest.ApiException as rest_exception:
+            if rest_exception.status == 401:
+                raise Exception(
+                    "You do not have permission to get templates",
+                )
+            raise
+        else:
+            self.templates = templates
+
+
+class GetCmd(InitKube):
+    """
+    GetCmd gets templates and their
+    values.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self.parser.add_argument(
+            "get_object",
+            metavar="G",
+            type=str,
+            help="print OpenShift object, supported arguments:\n"
+            "template_names: names of available OpenShift templates\n"
+            "template_params: OpenShift template parameters\n"
+            "templates: OpenShift templates\n"
+            "pods: OpenShift pods\n"
+            "services: OpenShift services\n"
+            "deploymentconfig: OpenShift deployment configurations\n"
+            "deployment: OpenShift deployments\n"
+            "pvc: OpenShift persistent volume claims\n"
+            "secrets: OpenShift secrets\n"
+            "routes: OpenShift routes\n",
         )
 
     def main(self, args):
-        v1_depl = self.dyn_client.resources.get(api_version="v1", kind="Deployment")
-        try:
-            depl_list = v1_depl.get(namespace=args.namespace)
-        except client.rest.ApiException as rest_exception:
-            if rest_exception.status == 403:
-                raise Exception(
-                    "You do not have permission to list deployments in namespace",
-                    args.namespace,
+        super().main(args)
+
+        if args.get_object == "template_names":
+            for n in range(len(self.templates["items"])):
+                print(self.templates["items"][n]["metadata"]["name"])
+        elif args.get_object == "template_params":
+            for n in range(len(self.templates["items"])):
+                print(
+                    self.templates["items"][n]["metadata"]["name"] + "\n",
+                    self.templates["items"][n]["parameters"],
                 )
+                print("")
+        elif args.get_object == "templates":
+            for t in self.templates["items"]:
+                print(t)
+                print("")
+        else:
+            try:
+                output = subprocess.check_output(("oc", "get", args.get_object))
+            except:
+                raise
+            else:
+                print(output.decode("utf-8").replace("\\n", "\n"))
+
+
+class TranslateCmd(InitKube):
+    """
+    TranslateCmd translates a Flux jobspec V1
+    into the corresponding K8s/OpenShift template
+    and applies template overrides.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self.logger = logging.getLogger("flux-kube")
+        self.parser.add_argument(
+            "-j",
+            "--jobspec",
+            type=str,
+            metavar="J",
+            help="path to Flux jobspec",
+        )
+        self.parser.add_argument(
+            "-s",
+            "--string",
+            type=str,
+            metavar="S",
+            help="Flux jobspec string",
+        )
+
+    def main(self, args):
+        super().main(args)
+
+        if args.jobspec:
+            try:
+                with open(args.jobspec, "r") as f:
+                    self.jobspec = yaml.safe_load(f)
+            except IOError as e:
+                self.logger.error(e)
+                raise
+        elif args.string:
+            try:
+                tmp_jobspec = yaml.safe_load(args.string)
+                if "jobspec" in tmp_jobspec:
+                    self.jobspec = tmp_jobspec["jobspec"]
+                else:
+                    self.jobspec = tmp_jobspec
+            except Exception as e:
+                self.logger.error(e)
+                raise
+
+        # Transform templates to be keyed by service name to pass
+        # to translation library
+        self.trans_templates = {}
+        for n in range(len(self.templates["items"])):
+            self.trans_templates[
+                (self.templates["items"][n]["metadata"]["name"])
+            ] = self.templates["items"][n]
+        try:
+            js_translator = JobspecTranslator(self.jobspec, self.trans_templates)
+            self.service = js_translator.translate()
+        except Exception as e:
+            self.logger.error(e)
             raise
 
-        if depl_list.items:
-            for depl in depl_list.items:
-                print("Deployment name:", depl.metadata.name)
-                for item in depl:
-                    print(item)
+
+class SubmitCmd(TranslateCmd):
+    """
+    SubmitCmd translates a Flux jobspec V1
+    into the corresponding K8s/OpenShift template
+    and applies template overrides. Then it
+    creates the corresponding objects via `oc create`.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def main(self, args):
+        super().main(args)
+
+        cmd = [
+            "oc",
+            "process",
+            args.namespace + "//" + self.service["template"]["metadata"]["name"],
+        ]
+
+        for k, v in self.service["overrides"].items():
+            cmd.extend(("-p", k + "=" + v))
+
+        try:
+            ps = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+            output = subprocess.check_output(
+                ("oc", "create", "-f", "-"), stdin=ps.stdout, stderr=subprocess.STDOUT
+            )
+            ps.wait()
+        except subprocess.CalledProcessError as e:
+            if "AlreadyExists" in str(e.stdout):
+                pass
+            else:
+                self.logger.error(e)
+                raise
+
+
+class CancelCmd(TranslateCmd):
+    """
+    CancelCmd translates a Flux jobspec V1
+    into the corresponding K8s/OpenShift template
+    and applies template overrides. Then it
+    deletes the corresponding objects via `oc delete`.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def main(self, args):
+        super().main(args)
+
+        cmd = [
+            "oc",
+            "process",
+            args.namespace + "//" + self.service["template"]["metadata"]["name"],
+        ]
+
+        for k, v in self.service["overrides"].items():
+            cmd.extend(("-p", k + "=" + v))
+
+        try:
+            ps = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+            (
+                subprocess.check_output(
+                    ("oc", "delete", "-f", "-"),
+                    stdin=ps.stdout,
+                    stderr=subprocess.STDOUT,
+                )
+            )
+            ps.wait()
+        except subprocess.CalledProcessError as e:
+            if "Error from server (NotFound)" in str(e.output):
+                self.logger.warning(
+                    "Can't cancel nonexistent objects:\n" + str(e.output)
+                )
+            else:
+                self.logger.error(e)
+                raise
+        except Exception as e:
+            self.logger.error(e)
+            raise
+
+
+class MiniCmd(KubeCmd):
+    """
+    MiniCmd takes a template name and
+    overrides as arguments and constucts a skeleton
+    jobspec based on the arguments. It then invokes
+    SubmitCmd to create the objects or CancelCmd
+    to delete them.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self.logger = logging.getLogger("flux-kube")
+        self.parser.add_argument(
+            "mini",
+            type=str,
+            metavar="M",
+            help="mini command: submit or cancel",
+        )
+        self.parser.add_argument(
+            "template_name",
+            type=str,
+            metavar="T",
+            help="template to submit/cancel",
+        )
+        self.parser.add_argument(
+            "-o",
+            "--overrides",
+            type=str,
+            metavar="OR",
+            default="{}",
+            help="template overrides",
+        )
+
+    def main(self, args):
+        # Dummy jobspec that gets translated to a template with overrides
+        jobspec = (
+            '{"tasks": [{"command": ["' + args.template_name + '"]}], '
+            '"attributes": {"system": {"flux-kube": 1, '
+            '"template_overrides": ' + args.overrides + "}}}"
+        )
+
+        if args.mini == "submit":
+            submit = SubmitCmd()
+            submit.main(submit.parser.parse_args(["-s", jobspec]))
+        elif args.mini == "cancel":
+            cancel = CancelCmd()
+            cancel.main(cancel.parser.parse_args(["-s", jobspec]))
         else:
-            print("No deployments in namespace", args.namespace)
+            self.logger.error("Error: unrecognized mini command")
+
+
+class FluxKubeDaemon:
+    """
+    FluxKubeDaemon registers the fluxkube service,
+    and starts a request message watcher callback
+    which submits or cancels jobspec payload from
+    the flux-kube jobtap plugin.
+    """
+
+    def __init__(self):
+        self.logger = logging.getLogger("flux-kube")
+        self.flux_h = flux.Flux()
+
+    def main(self, args):
+        # Register the service in main since @util.CLIMain
+        # will invoke __init__ for each CLI command
+        # execution
+        self.flux_h.service_register("fluxkube").get()
+        submit = SubmitCmd()
+        cancel = CancelCmd()
+        self.submit_parser = submit.parser
+        self.cancel_parser = cancel.parser
+
+        def submit_jobspec(flux_h, t, msg, arg):
+            try:
+                submit.main(
+                    self.submit_parser.parse_args(["-s", msg.payload["jobspec"]])
+                )
+            except Exception as e:
+                self.logger.error(e)
+                flux_h.respond_error(msg,  errno.EPROTO, None)
+            else:
+                flux_h.respond(msg)
+
+        def cancel_jobspec(flux_h, t, msg, arg):
+            try:
+                cancel.main(
+                    self.cancel_parser.parse_args(["-s", msg.payload["jobspec"]])
+                )
+            except Exception as e:
+                self.logger.error(e)
+                flux_h.respond_error(msg,  errno.EPROTO, None)
+            else:
+                flux_h.respond(msg)
+
+        submit_watcher = self.flux_h.msg_watcher_create(
+            submit_jobspec, FLUX_MSGTYPE_REQUEST, "fluxkube.submit"
+        )
+        cancel_watcher = self.flux_h.msg_watcher_create(
+            cancel_jobspec, FLUX_MSGTYPE_REQUEST, "fluxkube.cancel"
+        )
+        submit_watcher.start()
+        cancel_watcher.start()
+
+        self.flux_h.reactor_run()
 
 
 LOGGER = logging.getLogger("flux-kube")
@@ -94,20 +405,70 @@ LOGGER = logging.getLogger("flux-kube")
 @util.CLIMain(LOGGER)
 def main():
 
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
     parser = argparse.ArgumentParser(prog="flux-kube")
     subparsers = parser.add_subparsers(
         title="supported subcommands", description="", dest="subcommand"
     )
     subparsers.required = True
 
-    getdeployments = GetDeploymentsCmd()
-    getdeployments_parser_sub = subparsers.add_parser(
-        "getdeployments",
-        parents=[getdeployments.get_parser()],
-        help="get K8s deployment details",
+    get = GetCmd()
+    get_parser_sub = subparsers.add_parser(
+        "get",
+        parents=[get.get_parser()],
+        help="get template names, parameters, and values, "
+        "and common OpenShift/K8s objects",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    get_parser_sub.set_defaults(func=get.main)
+
+    translate = TranslateCmd()
+    translate_parser_sub = subparsers.add_parser(
+        "translate",
+        parents=[translate.get_parser()],
+        help="translate jobspec into K8s template",
         formatter_class=util.help_formatter(),
     )
-    getdeployments_parser_sub.set_defaults(func=getdeployments.main)
+    translate_parser_sub.set_defaults(func=translate.main)
+
+    submit = SubmitCmd()
+    submit_parser_sub = subparsers.add_parser(
+        "submit",
+        parents=[submit.get_parser()],
+        help="submit jobspec into K8s template",
+        formatter_class=util.help_formatter(),
+    )
+    submit_parser_sub.set_defaults(func=submit.main)
+
+    cancel = CancelCmd()
+    cancel_parser_sub = subparsers.add_parser(
+        "cancel",
+        parents=[cancel.get_parser()],
+        help="delete objects corresponding to Openshift template",
+        formatter_class=util.help_formatter(),
+    )
+    cancel_parser_sub.set_defaults(func=cancel.main)
+
+    mini = MiniCmd()
+    mini_parser_sub = subparsers.add_parser(
+        "mini",
+        parents=[mini.get_parser()],
+        help="generates a skeleton jobspec with the specified "
+        "OpenShift template and template parameter overrides and "
+        "creates the corresponding objects (submit) "
+        "or deletes them (cancel)",
+        formatter_class=util.help_formatter(),
+    )
+    mini_parser_sub.set_defaults(func=mini.main)
+
+    daemon = FluxKubeDaemon()
+    daemon_parser_sub = subparsers.add_parser(
+        "daemonize",
+        help="daemonize the submission",
+        formatter_class=util.help_formatter(),
+    )
+    daemon_parser_sub.set_defaults(func=daemon.main)
 
     args = parser.parse_args()
     args.func(args)

--- a/flux-kube/configure.ac
+++ b/flux-kube/configure.ac
@@ -14,8 +14,19 @@ AM_MAINTAINER_MODE([enable])
 
 AC_PREFIX_PROGRAM([flux])
 
-# Check for C compiler
-# AC_PROG_CC
+LT_INIT([dlopen])
+
+PKG_PROG_PKG_CONFIG
+
+# Checks for programs.
+AC_DEFINE([_GNU_SOURCE], 1,
+          [Define _GNU_SOURCE so that we get all necessary prototypes])
+AC_PROG_CC
+AC_PROG_CC_C99
+AC_PROG_LN_S
+AC_PROG_MAKE_SET
+AM_PROG_CC_C_O
+
 # We can add more checks in this section
 AX_FLUX_CORE
 
@@ -38,11 +49,21 @@ AM_CHECK_PYMOD(openshift,
 AS_VAR_SET(fluxcmddir, $libexecdir/flux/cmd)
 AC_SUBST(fluxcmddir)
 
+AS_VAR_SET(jobtap_plugindir, $libdir/flux/job-manager/plugins)
+AC_SUBST(jobtap_plugindir)
+
+##
+# Macros to avoid repetition in Makefiles.am's
+##
+fluxplugin_ldflags="-avoid-version -export-symbols-regex '^flux_plugin_init\$\$' --disable-static -shared -export-dynamic -module"
+AC_SUBST(fluxplugin_ldflags)
+
 # Tells automake to create a Makefile
 # See https://www.gnu.org/software/automake/manual/html_node/Requirements.html
 AC_CONFIG_FILES([Makefile
   cmd/Makefile
-  lib/Makefile])
+  lib/Makefile
+  plugins/Makefile])
 
 # Generate the output
 AC_OUTPUT

--- a/flux-kube/configure.ac
+++ b/flux-kube/configure.ac
@@ -10,7 +10,6 @@ AC_CONFIG_SRCDIR([NEWS])
 
 AM_INIT_AUTOMAKE([subdir-objects tar-ustar filename-length-max=256 foreign])
 AM_SILENT_RULES([yes])
-# AM_CONFIG_HEADER([config.h])
 AM_MAINTAINER_MODE([enable])
 
 AC_PREFIX_PROGRAM([flux])
@@ -42,7 +41,8 @@ AC_SUBST(fluxcmddir)
 # Tells automake to create a Makefile
 # See https://www.gnu.org/software/automake/manual/html_node/Requirements.html
 AC_CONFIG_FILES([Makefile
-  cmd/Makefile])
+  cmd/Makefile
+  lib/Makefile])
 
 # Generate the output
 AC_OUTPUT

--- a/flux-kube/configure.ac
+++ b/flux-kube/configure.ac
@@ -52,6 +52,9 @@ AC_SUBST(fluxcmddir)
 AS_VAR_SET(jobtap_plugindir, $libdir/flux/job-manager/plugins)
 AC_SUBST(jobtap_plugindir)
 
+AS_VAR_SET(fluxrc1dir, $sysconfdir/flux/rc1.d)
+AC_SUBST(fluxrc1dir)
+
 ##
 # Macros to avoid repetition in Makefiles.am's
 ##
@@ -63,7 +66,8 @@ AC_SUBST(fluxplugin_ldflags)
 AC_CONFIG_FILES([Makefile
   cmd/Makefile
   lib/Makefile
-  plugins/Makefile])
+  plugins/Makefile
+  etc/Makefile])
 
 # Generate the output
 AC_OUTPUT

--- a/flux-kube/etc/01-flux-kube-daemon
+++ b/flux-kube/etc/01-flux-kube-daemon
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Submit flux kube daemon as a job 
+# so it is cleaned up when flux exits
+if test $(flux getattr rank) -eq 0; then
+    flux jobtap load alloc-bypass.so
+    flux mini submit \
+         --setattr=system.alloc-bypass.R="$(flux kvs get resource.R \
+         | flux R decode --include=0)" \
+         flux kube daemonize
+fi

--- a/flux-kube/etc/Makefile.am
+++ b/flux-kube/etc/Makefile.am
@@ -1,0 +1,2 @@
+dist_fluxrc1_SCRIPTS = \
+	01-flux-kube-daemon

--- a/flux-kube/lib/Makefile.am
+++ b/flux-kube/lib/Makefile.am
@@ -1,0 +1,2 @@
+dist_fluxcmd_SCRIPTS = \
+	kube_translator.py

--- a/flux-kube/lib/kube_translator.py
+++ b/flux-kube/lib/kube_translator.py
@@ -1,0 +1,83 @@
+##############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import warnings
+
+
+class JobspecTranslator:
+    """
+    JobspecTranslator is a base class for mapping and translating
+    a jobspec with template overrides into a Kubernetes
+    or OpenShift template.
+    """
+
+    def __init__(self, jobspec_dict, templates_dict):
+        """
+        args:
+             jobspec_dict is the YAML jobspec ingested as a dict
+             templates_dict is a dictionary keyed by the cluster
+                  service template names, with values of the templates
+                  themselves
+        """
+        self.jobspec = jobspec_dict
+        self.templates = templates_dict
+
+        # Check for multiple services per jobspec, which is
+        # currently unsupported.
+        if len(self.jobspec["tasks"]) > 1:
+            raise NotImplementedError(
+                "Requesting multiple services per " "jobspec is currently unsupported\n"
+            )
+
+        if len(self.jobspec["tasks"][0]["command"]) > 1:
+            raise NotImplementedError(
+                "Requesting multiple services per " "jobspec is currently unsupported\n"
+            )
+
+        # Check if the service name requested matches a known template
+        try:
+            self.service = {
+                "template": self.templates[(self.jobspec["tasks"][0]["command"][0])]
+            }
+        except KeyError:
+            print(
+                "service %s not a registered template on the cluster\n"
+                % self.jobspec["tasks"][0]["command"]
+            )
+            raise
+
+    def translate(self):
+        if "template_overrides" in self.jobspec["attributes"]["system"]:
+            param_names = set()
+            self.service["overrides"] = {}
+            for override in self.jobspec["attributes"]["system"]["template_overrides"]:
+                matched = False
+                for param in self.service["template"]["parameters"]:
+                    if override in param_names:
+                        (self.service["overrides"][override]) = self.jobspec[
+                            "attributes"
+                        ]["system"]["template_overrides"][override]
+                        matched = True
+                    else:
+                        if param["name"] not in param_names:
+                            param_names.update([param["name"]])
+                        if param["name"] == override:
+                            (self.service["overrides"][override]) = self.jobspec[
+                                "attributes"
+                            ]["system"]["template_overrides"][override]
+                            matched = True
+                if not matched:
+                    warnings.warn(
+                        "Warning: specified overrides do not match "
+                        "template parameters\n",
+                        SyntaxWarning,
+                    )
+
+            return self.service

--- a/flux-kube/plugins/Makefile.am
+++ b/flux-kube/plugins/Makefile.am
@@ -1,0 +1,18 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) 
+
+AM_CPPFLAGS = \
+	-I$(FLUX_PREFIX) \
+	-I$(FLUX_PREFIX)/src/include \
+	-I$(FLUX_PREFIX)/src/common/libflux \
+	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
+
+jobtap_plugin_LTLIBRARIES = \
+	flux-kube.la
+
+flux_kube_la_SOURCES = \
+	flux-kube.c
+
+flux_kube_la_LDFLAGS = \
+	$(fluxplugin_ldflags) \
+	-module

--- a/flux-kube/plugins/flux-kube.c
+++ b/flux-kube/plugins/flux-kube.c
@@ -1,0 +1,364 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* flux-kube.c - If attributes.system.R exists in jobspec, then
+ *  bypass scheduler alloc protocol and use R directly (for instance
+ *  owner use only)
+ */
+
+#include <unistd.h>
+#include <sys/types.h>
+
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+static void alloc_continuation (flux_future_t *f, void *arg)
+{
+    flux_plugin_t *p = arg;
+    flux_jobid_t *idptr = flux_future_aux_get (f, "jobid");
+
+    if (!idptr) {
+        errno = EINVAL;
+        flux_log_error (flux_jobtap_get_flux (p),
+                        "Failed to get jobid");
+        goto done;     
+    }
+
+    if (flux_future_get (f, NULL) < 0) {
+        flux_jobtap_raise_exception (p,
+                                     *idptr,
+                                     "alloc", 0,
+                                     "failed to commit R to kvs: %s",
+                                      strerror (errno));
+        goto done;
+    }
+
+    if (flux_jobtap_event_post_pack (p,
+                                     *idptr,
+                                     "alloc",
+                                     "{s:b}",
+                                     "bypass", true) < 0) {
+        flux_jobtap_raise_exception (p,
+                                     *idptr,
+                                     "alloc", 0,
+                                     "failed to post alloc event: %s",
+                                     strerror (errno));
+        goto done;
+    }
+
+    /*  Set "needs-free" so that flux-kube knows that a "free"
+     *  event needs to be emitted for this node.
+     */
+    if (flux_jobtap_job_aux_set (p, *idptr, "flux-kube::free", p, NULL) < 0)
+        flux_log_error (flux_jobtap_get_flux (p),
+                        "id=%ju: Failed to set flux-kube::free",
+                        (intmax_t)(*idptr));
+
+done:
+    flux_future_destroy (f);
+}
+
+static void get_response_continuation (flux_future_t *f, void *arg)
+{
+    flux_plugin_t *p = arg;
+
+    if (flux_rpc_get (f, NULL) != 0)
+        flux_log_error (flux_jobtap_get_flux (p),
+                        "Failed to unpack RPC from flux-kube.py");
+
+
+    flux_future_destroy (f);
+}
+
+static int alloc_start (flux_plugin_t *p,
+                        flux_jobid_t id,
+                        const char *R)
+{
+    flux_t *h;
+    char key[64];
+    int saved_errno = 0;
+    flux_future_t *f = NULL;
+    flux_kvs_txn_t *txn = NULL;
+    flux_jobid_t *idptr = NULL;
+
+    if (!(h = flux_jobtap_get_flux (p))
+        || flux_job_kvs_key (key, sizeof (key), id, "R") < 0
+        || !(txn = flux_kvs_txn_create ())
+        || flux_kvs_txn_put (txn, 0, key, R) < 0
+        || !(f = flux_kvs_commit (h, NULL, 0, txn))
+        || flux_future_then (f, -1, alloc_continuation, p)
+        || !(idptr = calloc (1, sizeof (*idptr)))
+        || flux_future_aux_set (f, "jobid", idptr, free) < 0) {
+        flux_kvs_txn_destroy (txn);
+        flux_future_destroy (f);
+        saved_errno = errno;
+        free (idptr);
+        errno = saved_errno;
+        return -1;
+    }
+    *idptr = id;
+    flux_kvs_txn_destroy (txn);
+    return 0;
+}
+
+
+static int sched_cb (flux_plugin_t *p,
+                     const char *topic,
+                     flux_plugin_arg_t *args,
+                     void *arg)
+{
+    const char *R = NULL, *jobspec = NULL;
+    flux_jobid_t id;
+    flux_future_t *f;
+
+    /*  If flux-kube::R set on this job then commit R to KVS,
+     *  get the jobspec, submit the jobspec to flux-kube.py, 
+     *  and set flux-kube flag.
+     */
+    if (!(R = flux_jobtap_job_aux_get (p,
+                                       FLUX_JOBTAP_CURRENT_JOB,
+                                       "flux-kube::R")))
+        return 0;
+
+    if (!(jobspec = flux_jobtap_job_aux_get (p,
+                                             FLUX_JOBTAP_CURRENT_JOB,
+                                             "flux-kube::jobspec"))) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "flux-kube: failed to get jobspec",
+                                     topic,
+                                     flux_plugin_arg_strerror (args));
+        return -1;
+        }
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I}",
+                                "id", &id) < 0) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "flux-kube: %s: unpack: %s",
+                                     topic,
+                                     flux_plugin_arg_strerror (args));
+        return -1;
+    }
+
+    if (!(f = flux_rpc_pack (flux_jobtap_get_flux (p), "fluxkube.submit", 
+                             FLUX_NODEID_ANY, 0,
+                             "{s:s}", "jobspec", jobspec))) { 
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "flux-kube: %s: Failed to send RPC: %s",
+                                     topic,
+                                     strerror (errno));
+        return -1;
+    }
+    
+    if (flux_future_then (f, -1.0f, get_response_continuation, p) < 0) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "flux-kube: %s: Failed to "
+                                     "submit jobspec: %s",
+                                     topic,
+                                     strerror (errno));
+        return -1;
+    }
+
+    if (alloc_start (p, id, R) < 0) {
+        flux_jobtap_raise_exception (p, id, "alloc", 0,
+                                     "failed to start allocation");
+        return -1;
+    }
+
+    if (flux_jobtap_job_set_flag (p,
+                                  FLUX_JOBTAP_CURRENT_JOB,
+                                  "alloc-bypass") < 0) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "Failed to set alloc-bypass: %s",
+                                     strerror (errno));
+        return -1;
+    }
+
+    return 0;
+}
+
+static int cleanup_cb (flux_plugin_t *p,
+                       const char *topic,
+                       flux_plugin_arg_t *args,
+                       void *arg)
+{
+    const char *jobspec = NULL;
+    flux_future_t *f;
+
+    /*  Need to get the jobspec and send it to flux-kube daemon 
+     *  for cancellation.
+     */
+    if (!(jobspec = flux_jobtap_job_aux_get (p,
+                                             FLUX_JOBTAP_CURRENT_JOB,
+                                             "flux-kube::jobspec")))
+        return 0;
+
+    if (!(f = flux_rpc_pack (flux_jobtap_get_flux (p), "fluxkube.cancel", 
+                             FLUX_NODEID_ANY, 0,
+                             "{s:s}", "jobspec", jobspec))) { 
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "flux-kube: %s: Failed to send RPC: %s",
+                                     topic,
+                                     strerror (errno));
+        return -1;
+    }
+    
+    if (flux_future_then (f, -1.0f, get_response_continuation, p) < 0) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "flux-kube: %s: Failed to "
+                                     "cancel jobspec: %s",
+                                     topic,
+                                     strerror (errno));
+        return -1;
+    }
+
+    /*  If flux-kube::free is set on this job, then this plugin
+     *  sent an "alloc" event, so a "free" event needs to be sent now.
+     */
+    if (flux_jobtap_job_aux_get (p,
+                                 FLUX_JOBTAP_CURRENT_JOB,
+                                 "flux-kube::free")) {
+        if (flux_jobtap_event_post_pack (p,
+                                         FLUX_JOBTAP_CURRENT_JOB,
+                                         "free",
+                                         NULL) < 0)
+             flux_log_error (flux_jobtap_get_flux (p),
+                             "flux-kube: failed to post free event");
+    }
+    return 0;
+}
+
+static int validate_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *arg)
+{
+    int fluxkube = 0, saved_errno = 0;
+    json_t *jobspec = NULL, *R = NULL;
+    char *js = NULL, *Rstring = NULL;
+    uint32_t userid = UINT32_MAX;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:i s:{s:{s:{s?i}}}}",
+                                "userid", &userid,
+                                "jobspec",
+                                 "attributes",
+                                  "system",
+                                   "flux-kube", &fluxkube) < 0) {
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "invalid system.flux-kube: %s",
+                                       flux_plugin_arg_strerror (args));
+    }
+
+    //  Nothing to do if not fluxkube
+    if (!fluxkube)
+        return 0;
+
+    if (userid != getuid ())
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "Guest user cannot set flux-kube "
+                                       "attribute");
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:o}",
+                                "jobspec", &jobspec) < 0) {
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "invalid jobspec: %s",
+                                       flux_plugin_arg_strerror (args));
+    }
+   /*  Store jobspec in job structure to avoid re-fetching from plugin args
+    *  in job.state.sched callback.
+    */
+    if (!(js = json_dumps (jobspec, 0))) {
+        saved_errno = ENOMEM;
+        free (js);
+        errno = saved_errno;
+        return -1;
+    }
+
+    if (flux_jobtap_job_aux_set (p,
+                                 FLUX_JOBTAP_CURRENT_JOB,
+                                 "flux-kube::jobspec",
+                                 js,
+                                 free) < 0) {
+        saved_errno = errno;
+        free (js);
+        errno = saved_errno;
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "failed to capture flux-kube "
+                                       "jobspec: %s",
+                                       strerror (errno));
+    }
+    /*  Store R string in job structure to avoid re-fetching from plugin args
+     *  in job.state.sched callback.
+     */
+    R = json_pack ("{s:i s:{s:[{s:s s:{s:s}}] s:f s:f s:[s]}}", 
+                   "version", 1, 
+                   "execution", 
+                           "R_lite",
+                                "rank", "0",
+                                "children",
+                                       "core", "0",
+                           "starttime", 0.0, 
+                           "expiration", 0.0,
+                           "nodelist", 
+                                  "kubernetes");
+
+    if (!(Rstring = json_dumps (R, 0))) {
+        saved_errno = ENOMEM;
+        free (R);
+        free (Rstring);
+        errno = saved_errno;
+        return -1;
+    }
+    free (R);
+
+    if (flux_jobtap_job_aux_set (p,
+                                 FLUX_JOBTAP_CURRENT_JOB,
+                                 "flux-kube::R", 
+                                 Rstring, 
+                                 free) < 0)
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "failed to capture flux-kube R: %s",
+                                       strerror (errno));
+    return 0;
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.state.sched",   sched_cb,    NULL },
+    { "job.state.cleanup", cleanup_cb,  NULL },
+    { "job.validate",      validate_cb, NULL },
+    { 0 }
+};
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    return flux_plugin_register (p, "flux-kube", tab);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This PR adds all the functionality needed for the Unified Interface project.  It features three classes of functionality.

First, the functionality of mapping a Flux jobspec to an OpenShift template. The library takes a Flux jobspec and matches the jobspec command to a corresponding OpenShift template name. It then matches the template parameter overrides specified in the jobspec's system attributes to the overrides available in the selected template. The library returns a service, which is the selected template with the dictionary of parameter overrides.

Second, this PR adds the `flux-kube.so` jobtap plugin and the associated machinery to build and install it. The jobtap plugin is based on alloc-bypass.so (flux-core `90461710f1f09ed48cc7586abff5cb4fee6dc63d`). Upon ingest, the plugin looks for attributes.system.flux-kube set in the jobspec. If it's present, the plugin sets the "alloc-bypass" flag, passes the jobspec to flux-kube.py via RPC, and unpacks the response. Then the plugin generates a dummy R (since the resources will reside on OpenShift) and commits it to the KVS. Finally, the plugin emits an "alloc" event and then submits the jobspec via asynchronous RPC to the `flux kube` daemon for creation of OpenShift objects.  Cancellation works analogously, sending the stored jobspec to the `flux kube` daemon via an asynchronous RPC.

Third, this PR adds the fully-featured `flux kube` CLI and daemon.  The CLI features `translate`, `submit`, `cancel`, and `daemonize` subcommands.  Translate uses kube_translate.py to translate a Flux jobspec into an OpenShift template with parameter overrides read from system.attributes.  Submit takes either a jobspec or string input and creates the corresponding OpenShift objects.  Unfortunately, the OpenShift APIs do not have the required functionality (present in the `oc` binary) to convert templates to object YAMLs.  Therefore, we must call `oc process` and pipe it to `oc create` via Python subprocess calls.  Cancel works similarly to `submit`, but deletes the OpenShift objects.

Daemonize registers a Flux service that creates a watcher callback for jobspecs sent via RPC from the `flux-kube.so` jobtap.  It creates the OpenShift objects and returns a success/failure value to the jobtap.  The daemon is started as a job at rc1 via `flux mini submit` so that it can be cleaned up when Flux exits.

Much of the functionality of this PR requires OpenShift templates.  The functionality will be extended to interface with base K8s CRDs (which can replicate the template functionality) in the future.
