### PR TITLE
Update rc1 script to load flux-kube.so

### DIFF
--- a/flux-kube/etc/01-flux-kube-daemon
+++ b/flux-kube/etc/01-flux-kube-daemon
@@ -4,6 +4,7 @@
 # so it is cleaned up when flux exits
 if test $(flux getattr rank) -eq 0; then
     flux jobtap load alloc-bypass.so
+    flux jobtap load flux-kube.so
     flux mini submit \
          --setattr=system.alloc-bypass.R="$(flux kvs get resource.R \
          | flux R decode --include=0)" \


### PR DESCRIPTION
Add a line in `01-flux-kube-daemon` to load `flux-kube.so` at start time. This is a convenience for users since they will not need to do so manually.