### PR TITLE
Adds job cancellation of flux jobs

### DIFF
--- a/flux-plugin/kubeflux/kubeflux.go
+++ b/flux-plugin/kubeflux/kubeflux.go
@@ -232,8 +232,7 @@ func New(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
 	return kf, nil
 }
 
-////// EventHandlers
-
+// EventHandlers
 func (kf *KubeFlux) updatePod(oldObj, newObj interface{}) {
 	fmt.Println("updatePod event handler")
 	oldPod := oldObj.(*v1.Pod)


### PR DESCRIPTION
This PR adds flux job cancellation function to kubeflux scheduler which enables kubeflux to cancel a flux job after it's corresponding pod completed (Its `PodPhase` can be either `PodSucceeded` or `PodFailed`). Thus the previously allocated resources can be freed and reused.

- Add `PodInformer` to watch pod event. Job cancellation is implemented in the update event handler.
- Each pod's jobspec yaml is stored in its own yaml file instead of being overwritten when a new pod is being scheduled.  