### PR TITLE
Add Pi calculation program in examples

### DIFF
--- a/examples/pi/.gitignore
+++ b/examples/pi/.gitignore
@@ -1,0 +1,2 @@
+logs/
+demo/

--- a/examples/pi/Dockerfile
+++ b/examples/pi/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:latest
+MAINTAINER Eduardo Arango <carlos.arango.gutierrez@correounivalle.edu.co>
+
+RUN apt-get update
+RUN apt-get install -y bash wget build-essential gcc g++ git
+RUN git clone https://github.com/ArangoGutierrez/Pi.git
+WORKDIR Pi
+RUN g++ -fopenmp pi.c -o pi
+RUN cp pi /bin
+
+ENTRYPOINT ["pi","5000"]

--- a/examples/pi/Dockerfile.segfault
+++ b/examples/pi/Dockerfile.segfault
@@ -1,0 +1,11 @@
+FROM ubuntu:latest
+MAINTAINER Eduardo Arango <carlos.arango.gutierrez@correounivalle.edu.co>
+
+RUN apt-get update
+RUN apt-get install -y bash wget build-essential gcc g++ git
+RUN git clone https://github.com/ArangoGutierrez/Pi.git
+WORKDIR Pi
+RUN g++ -fopenmp pi.c -o pi
+RUN cp pi /bin
+
+ENTRYPOINT ["pi"]

--- a/examples/pi/Makefile
+++ b/examples/pi/Makefile
@@ -1,0 +1,56 @@
+GITVERSION := $(shell git rev-parse --short HEAD)
+
+DOCKER_IMAGE_NAME=pi
+DOCKER_IMAGE_TAG=${GITVERSION}
+
+DOCKER_IMAGE=${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
+
+DOCKER_SEGFAULT_IMAGE_NAME=pi-segfault
+DOCKER_SEGFAULT_IMAGE=${DOCKER_SEGFAULT_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
+
+all:: build-image
+
+clean:: clean-image
+
+build-image:
+	@echo "Building Docker image...";
+	docker build -t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} .
+	docker tag ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ${DOCKER_IMAGE_NAME}:latest
+	docker tag ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} localhost:5000/${DOCKER_IMAGE_NAME}:latest
+
+build-segfault-image:
+	@echo "Building Docker image (pi-segfault)...";
+	docker build -t ${DOCKER_SEGFAULT_IMAGE_NAME}:${DOCKER_IMAGE_TAG} -f Dockerfile.segfault .
+	docker tag ${DOCKER_SEGFAULT_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ${DOCKER_SEGFAULT_IMAGE_NAME}:latest
+	docker tag ${DOCKER_SEGFAULT_IMAGE_NAME}:${DOCKER_IMAGE_TAG} localhost:5000/${DOCKER_SEGFAULT_IMAGE_NAME}:latest
+
+push-image-local:
+	@echo "Pushing Docker image..."; 
+	docker push localhost:5000/${DOCKER_IMAGE_NAME}:latest
+
+push-segfault-image-local:
+	@echo "Pushing Docker image (pi-segfault)..."; 
+	docker push localhost:5000/${DOCKER_SEGFAULT_IMAGE_NAME}:latest
+
+push-image:
+	@echo "Pushing Docker image..."; 
+	docker push ${DOCKER_IMAGE_NAME}:latest
+
+clean-image:
+	@echo "Cleaning Docker image...";
+	docker rmi -f ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ${DOCKER_IMAGE_NAME}:latest localhost:5000/${DOCKER_IMAGE_NAME}:latest
+
+setup-kubeflux:
+	kubectl create -f ./rbac.yaml
+	kubectl create -f ./kubesched.yaml
+
+reset-kubeflux:
+	kubectl delete -f ./kubesched.yaml
+	kubectl create -f ./kubesched.yaml
+
+check-kubeflux:
+	kubectl get pod -l app=kubeflux -n kube-system
+
+delete-kind:
+	kind delete cluster --name xyl-kind
+

--- a/examples/pi/README.md
+++ b/examples/pi/README.md
@@ -1,0 +1,81 @@
+# A Minimum Working Example for Kubeflux
+
+- [source](https://stackoverflow.com/questions/42564058/how-to-use-local-docker-images-with-minikube) 
+- [Pi](https://github.com/ArangoGutierrez/Pi)
+- [Multi-nodes solution](https://minikube.sigs.k8s.io/docs/handbook/registry/)
+- [reference](https://hasura.io/blog/sharing-a-local-registry-for-minikube-37c7240d0615/)
+## Setup
+    - local cluster: minikube
+    - Kubeflux: `kubesched.yaml`
+
+## Using local docker image in minikube (multi-node can not use this method)
+
+```bash
+# Start minikube
+minikube start --kuberbetes-version=1.19.8
+
+# Set docker env
+eval $(minikube docker-env)             # unix shells
+minikube docker-env | Invoke-Expression # PowerShell
+
+# Build image
+docker build -t pi:latest .
+
+# Run in minikube
+kubectl run hello-foo --image=pi:latest --restart=Never --image-pull-policy=Never
+
+# Check that it's running
+kubectl get pods
+
+eval $(minikube docker-env -u)
+```
+
+## Pushing to an in-cluster using Registry addon
+
+- [sources](https://minikube.sigs.k8s.io/docs/handbook/pushing/)
+- [refer](https://github.com/kubernetes/minikube/issues/6012)
+
+## Steps:
+
+```bash
+   # we can find plugin version by reading from logs command's output and find corresponding k8s version from https://github.com/cmisale/scheduler-plugins 
+   $ minikube start --kubernetes-version=v1.19.8
+   $ kubectl create -f rbac.yaml 
+   $ kubectl create -f ./kubesched.yaml 
+   # find correct pod name with command minikube kubectl -- get pods -A
+   $ kubectl logs -n kube-system  kubeflux-plugin-57c56dd87f-9c5km
+   $ kubectl create -f pi.yaml
+
+   $ POD=$(kubectl get pod -l app=kubeflux -n kube-system -o jsonpath="{.items[0].metadata.name}")
+   $ kubectl exec -it <podname> -n kube-system -- /bin/bash
+
+   $ kubectl exec -it $(kubectl get pod -l app=kubeflux -n kube-system -o jsonpath="{.items[0].metadata.name}") -n kube-system -- /bin/bash
+
+   $ kubectl cp kube-system/$(kubectl get pod -l app=kubeflux -n kube-system -o jsonpath="{.items[0].metadata.name}"):/home/data/jgf/kubecluster.json  kubecluster_cp.json
+```
+
+### How to copy file from pods to local
+
+ - [refer](https://stackoverflow.com/questions/52407277/how-to-copy-files-from-kubernetes-pods-to-local-system)
+
+ ```bash
+    kubectl cp kube-system/kubeflux-plugin-7b5fb86f5f-8wqq2:/home/data/jgf/kubecluster.json  kubecluster_before.json
+ ```
+
+ ### On CPU limit
+
+ - [refer](https://learnk8s.io/setting-cpu-memory-limits-requests)
+
+
+ ### Resource query
+
+ - [refer](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_4.html)
+
+ ### Kind local registry
+
+ - [refer](https://kind.sigs.k8s.io/docs/user/local-registry/)
+
+
+ ### Kind cluster with metrics server
+
+ - [refer](https://www.scmgalaxy.com/tutorials/kubernetes-metrics-server-error-readiness-probe-failed-http-probe-failed-with-statuscode/)

--- a/examples/pi/clean_pods.sh
+++ b/examples/pi/clean_pods.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+kubectl delete -f ./pi-job-kubeflux-segfault.yaml
+kubectl delete -f ./pi-job-kubeflux.yaml

--- a/examples/pi/demo_failed_pod_cancellation.sh
+++ b/examples/pi/demo_failed_pod_cancellation.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+kubectl create -f ./pi-job-kubeflux-segfault.yaml
+echo "wait 5 seconds"
+sleep 5
+kubectl create -f ./pi-job-kubeflux.yaml

--- a/examples/pi/init_kind_cluster.sh
+++ b/examples/pi/init_kind_cluster.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -o errexit
+
+# create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+# create a cluster with the local registry enabled in containerd
+cluster_name=${USER}-kind
+cat <<EOF | kind create cluster --name=${cluster_name} --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_name}:${reg_port}"]
+EOF
+
+# connect the registry to the cluster network
+# (the network may already be connected)
+docker network connect "kind" "${reg_name}" || true
+
+# Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF

--- a/examples/pi/kubesched.yaml
+++ b/examples/pi/kubesched.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubeflux-plugin
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: scheduler
+      tier: control-plane
+  template:
+    metadata:
+      labels:
+        component: scheduler
+        tier: control-plane
+        app: kubeflux
+    spec:
+      serviceAccountName: kubeflux
+#      nodeSelector:
+#        node-role.kubernetes.io/control-plane: ""
+#      tolerations:
+#      - key: "node-role.kubernetes.io/control-plane"
+#      - key: "node-role.kubernetes.io/master"
+      containers:
+        - image: quay.io/cmisale/kubeflux:latest
+        # - image: quay.io/cmisale/kubeflux:dev
+          imagePullPolicy: Always
+          command:
+          - /bin/kube-scheduler
+          - --leader-elect=false
+          - --config=/home/sched-config.yaml
+          - -v=9
+          name: kubeflux-plugin
+          securityContext:
+            privileged: true
+      hostNetwork: false
+      hostPID: false

--- a/examples/pi/pi-job-default.yaml
+++ b/examples/pi/pi-job-default.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pi-job-default-sched
+spec:
+  completions: 4
+  template:
+    metadata:
+      labels:
+        app: pi-test-default
+    spec:
+      containers:
+      - name: pi-test
+        image: localhost:5000/pi:latest # kind with local registry
+        resources:
+          limits:
+            cpu: "12"
+          requests:
+            cpu: "12"
+      restartPolicy: Never      

--- a/examples/pi/pi-job-kubeflux-segfault.yaml
+++ b/examples/pi/pi-job-kubeflux-segfault.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pi-job-kubeflux-sched-segfault
+spec:
+  completions: 4
+  template:
+    metadata:
+      labels:
+        app: pi-test-kubeflux-segfault
+    spec:
+      schedulerName: scheduling-plugin # comment this out to get it scheduled by the default scheduler
+      containers:
+      - name: pi-test
+        image: localhost:5000/pi-segfault:latest # kind with local registry
+        resources:
+          limits:
+            cpu: "8"
+          requests:
+            cpu: "8"
+      restartPolicy: Never

--- a/examples/pi/pi-job-kubeflux.yaml
+++ b/examples/pi/pi-job-kubeflux.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pi-job-kubeflux-sched
+spec:
+  completions: 4
+  template:
+    metadata:
+      labels:
+        app: pi-test-kubeflux
+    spec:
+      schedulerName: scheduling-plugin # comment this out to get it scheduled by the default scheduler
+      containers:
+      - name: pi-test
+        image: localhost:5000/pi:latest # kind with local registry
+        resources:
+          limits:
+            cpu: "8"
+          requests:
+            cpu: "8"
+      restartPolicy: Never      

--- a/examples/pi/pi.yaml
+++ b/examples/pi/pi.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pi
+spec:
+  containers:
+  - name: test-pi
+    image: localhost:5000/pi:latest
+  restartPolicy: Never

--- a/examples/pi/rbac.yaml
+++ b/examples/pi/rbac.yaml
@@ -1,0 +1,152 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubeflux
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - events
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - bindings
+      - pods/binding
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+      - extensions
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - storageclasses
+      - csinodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - update
+  - apiGroups:
+      - "events.k8s.io"
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeflux
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubeflux
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeflux
+subjects:
+  - kind: ServiceAccount
+    name: kubeflux
+    namespace: kube-system


### PR DESCRIPTION
A simple pi calculation example is added. The pi program can be deployed with default scheduler and kubeflux scheduler. Those can be used to test kubeflux scheduler. 3 YAML files are included, which can be used to deploy batch jobs:
- `pi-job-default.yaml` in this configuration, default scheduler is used to schedule those pods.
- `pi-job-kubeflux.yaml` in this configuration, kubeflux is used to schedule those pods.
- `pi-job-kubeflux-segfault.yaml`: those pods will end up in PodFailed PodPhase, exit code 139.