### PR TITLE
Attempt add webhook 2

### DIFF
--- a/.github/test-kind-config.yaml
+++ b/.github/test-kind-config.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -107,12 +107,21 @@ jobs:
         name: fluence_controller
         path: /tmp
 
+    - name: Make Space For Build
+      run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          
     - name: Load Docker images
       run: |
         ls /tmp/*.tar.gz
         docker load --input /tmp/fluence_sidecar_latest.tar.gz
+        rm /tmp/fluence_sidecar_latest.tar.gz
         docker load --input /tmp/fluence_latest.tar.gz
+        rm /tmp/fluence_latest.tar.gz
         docker load --input /tmp/fluence_controller_latest.tar.gz
+        rm /tmp/fluence_controller_latest.tar.gz
         docker image ls -a | grep fluence
 
     - name: Create Kind Cluster
@@ -121,6 +130,7 @@ jobs:
         cluster_name: kind
         kubectl_version: v1.28.2
         version: v0.20.0
+        config: ./.github/test-kind-config.yaml
         
     - name: Load Docker Containers into Kind
       env:
@@ -132,6 +142,11 @@ jobs:
         kind load docker-image ${fluence}
         kind load docker-image ${sidecar}
         kind load docker-image ${controller}
+
+    - name: Install Cert Manager
+      run: |
+        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.1/cert-manager.yaml
+        sleep 10
 
     - name: Test Fluence
       run: /bin/bash ./.github/test.sh

--- a/Makefile
+++ b/Makefile
@@ -27,15 +27,19 @@ prepare: clone
 	# These are entirely new directory structures
 	rm -rf $(CLONE_UPSTREAM)/pkg/fluence
 	rm -rf $(CLONE_UPSTREAM)/pkg/controllers/podgroup_controller.go
-	rm -rf $(CLONE_UPSTREAM)/manifests/fluence
+	rm -rf $(CLONE_UPSTREAM)/apis/scheduling/v1alpha1/podgroup_webhook.go
+	rm -rf $(CLONE_UPSTREAM)/cmd/controller/app/server.go
 	cp -R sig-scheduler-plugins/pkg/fluence $(CLONE_UPSTREAM)/pkg/fluence
 	cp -R sig-scheduler-plugins/pkg/controllers/* $(CLONE_UPSTREAM)/pkg/controllers/
 	# This is the one exception not from sig-scheduler-plugins because it is needed in both spots
 	cp -R src/fluence/fluxcli-grpc $(CLONE_UPSTREAM)/pkg/fluence/fluxcli-grpc
 	# These are files with subtle changes to add fluence
 	cp sig-scheduler-plugins/cmd/scheduler/main.go ./upstream/cmd/scheduler/main.go
-	cp sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml $(CLONE_UPSTREAM)/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+	cp sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/*.yaml $(CLONE_UPSTREAM)/manifests/install/charts/as-a-second-scheduler/templates/
+	cp sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/crds/*.yaml $(CLONE_UPSTREAM)/manifests/install/charts/as-a-second-scheduler/crds/
 	cp sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/values.yaml $(CLONE_UPSTREAM)/manifests/install/charts/as-a-second-scheduler/values.yaml
+	cp sig-scheduler-plugins/apis/scheduling/v1alpha1/podgroup_webhook.go $(CLONE_UPSTREAM)/apis/scheduling/v1alpha1/podgroup_webhook.go
+	cp sig-scheduler-plugins/cmd/controller/app/server.go $(CLONE_UPSTREAM)/cmd/controller/app/server.go
 
 build: prepare
 	REGISTRY=${REGISTRY} IMAGE=${SCHEDULER_IMAGE} CONTROLLER_IMAGE=${CONTROLLER_IMAGE} $(BASH) $(CLONE_UPSTREAM)/hack/build-images.sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fluence enables HPC-grade pod scheduling in Kubernetes via the [Kubernetes Sched
 
 ## Getting started
 
-For instructions on how to start Fluence on a K8s cluster, see [examples](examples/). Documentation and instructions for reproducing our CANOPIE2022 paper (citation below) can be found in the [canopie22-artifacts branch](https://github.com/flux-framework/flux-k8s/tree/canopie22-artifacts).
+For instructions on how to start Fluence on a K8s cluster, see [examples](examples/). Documentation and instructions for reproducing our CANOPIE-2022 paper (citation below) can be found in the [canopie22-artifacts branch](https://github.com/flux-framework/flux-k8s/tree/canopie22-artifacts).
 For background on the Flux framework and the Fluxion scheduler, you can take a look at our award-winning R&D100 submission: https://ipo.llnl.gov/sites/default/files/2022-02/Flux_RD100_Final.pdf. For next steps:
 
  - To understand how it works, see [Design](#design)
@@ -56,8 +56,13 @@ pods with different names cannot be part of the same group that needs to be sche
 ### Deploy
 
 We provide a set of pre-build containers [alongside the repository](https://github.com/orgs/flux-framework/packages?repo_name=flux-k8s)
-that you can easily use to deploy Fluence right away! You'll simply need to clone the proper helm charts, and then install to your cluster.
-We provide helper commands to do that.
+that you can easily use to deploy Fluence right away! You'll first need to install the certificate manager:
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.1/cert-manager.yaml
+```
+
+And then clone the proper helm charts, and then install to your cluster. We provide helper commands to do that.
 
 ```bash
 # This clones the upstream scheduler plugins code, we will add fluence to it!
@@ -131,7 +136,13 @@ docker push docker.io/vanessa/fluence-controller
 These steps will require a Kubernetes cluster to install to, and having pushed the plugin container to a registry. If you aren't using a cloud provider, you can create a local one with `kind`:
 
 ```bash
-kind create cluster
+kind create cluster --config ./examples/kind-config.yaml
+```
+
+And install the certificate manager:
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.1/cert-manager.yaml
 ```
 
 **Important** if you are developing or testing fluence, note that custom scheduler plugins don't seem to work out of the box with MiniKube (but everything works with kind). Likely there are extensions or similar that need to be configured with MiniKube (that we have not looked into).
@@ -456,7 +467,7 @@ Note that if you want to enable extra endpoints for the fluence kubectl plugin a
 helm install \
   --set scheduler.image=ghcr.io/vsoch/fluence:latest \
   --set scheduler.enableExternalService=true \
-  --set controller.image=vanessa/fluence-controller \
+  --set controller.image=ghcr.io/vsoch/fluence-controller \
   --set scheduler.sidecarimage=ghcr.io/vsoch/fluence-sidecar:latest \
         fluence as-a-second-scheduler/
 ```
@@ -485,6 +496,11 @@ And to create:
 ```bash
 kind create cluster --config ./kind-config.yaml
 ```
+
+#### TODO
+
+ - Try what [kueue does](https://github.com/kubernetes-sigs/kueue/blob/6d57813a52066dab412735deeeb60ebb0cdb8e8e/cmd/kueue/main.go#L146-L155) to not require cert-manager.
+ - Possible bug with using kind (with custom config we are scheduling things to the control plane) - need to verify this didn't start happening with mutating webhook addition.
 
 #### Vanessa Thinking
 

--- a/examples/simple_example/fluence-scheduler-pod.yaml
+++ b/examples/simple_example/fluence-scheduler-pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: fluence-scheduled-pod
+  name: fluence-scheduled-pod-1
   labels:
     name: scheduler-example
 spec:

--- a/sig-scheduler-plugins/apis/scheduling/v1alpha1/podgroup_webhook.go
+++ b/sig-scheduler-plugins/apis/scheduling/v1alpha1/podgroup_webhook.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2023 Lawrence Livermore National Security, LLC
+
+(c.f. AUTHORS, NOTICE.LLNS, COPYING)
+SPDX-License-Identifier: MIT
+*/
+
+// This file is not used, but maintained as the original addition of an OrasCache webhook
+
+package v1alpha1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var (
+	logger = ctrl.Log.WithName("setup")
+)
+
+// IMPORTANT: if you use the controller-runtime builder, it will derive this name automatically from the gvk (kind, version, etc. so find the actual created path in the logs)
+// kubectl describe mutatingwebhookconfigurations.admissionregistration.k8s.io
+// It will also only allow you to describe one object type with For()
+// This is disabled so we manually manage it - multiple types to a list did not work: config/webhook/manifests.yaml
+////kubebuilder:webhook:path=/mutate-v1-sidecar,mutating=true,failurePolicy=fail,sideEffects=None,groups=core;batch,resources=pods;jobs,verbs=create,versions=v1,name=morascache.kb.io,admissionReviewVersions=v1
+
+// NewMutatingWebhook allows us to keep the sidecarInjector private
+// If it's public it's exported and kubebuilder tries to add to zz_generated_deepcopy
+// and you get all kinds of terrible errors about admission.Decoder missing DeepCopyInto
+func NewMutatingWebhook(mgr manager.Manager) *fluenceWatcher {
+	return &fluenceWatcher{decoder: admission.NewDecoder(mgr.GetScheme())}
+}
+
+// mutate-v1-fluence
+
+type fluenceWatcher struct {
+	decoder *admission.Decoder
+}
+
+func (a *fluenceWatcher) Handle(ctx context.Context, req admission.Request) admission.Response {
+
+	logger.Info("Running webhook handle")
+	// First try for job
+	job := &batchv1.Job{}
+	err := a.decoder.Decode(req, job)
+	if err != nil {
+
+		// Try for a pod next
+		pod := &corev1.Pod{}
+		err := a.decoder.Decode(req, pod)
+		if err != nil {
+			logger.Error(err, "Admission error.")
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		// If we get here, we decoded a pod
+		/*err = a.InjectPod(pod)
+		if err != nil {
+			logger.Error("Inject pod error.", err)
+			return admission.Errored(http.StatusBadRequest, err)
+		}*/
+
+		// Mutate the fields in pod
+		marshalledPod, err := json.Marshal(pod)
+		if err != nil {
+			logger.Error(err, "Marshalling pod error.")
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+		logger.Info("Admission pod success.")
+		return admission.PatchResponseFromRaw(req.Object.Raw, marshalledPod)
+	}
+	/*
+	   // If we get here, we found a job
+	   err = a.InjectJob(job)
+
+	   	if err != nil {
+	   		logger.Error("Inject job error.", err)
+	   		return admission.Errored(http.StatusBadRequest, err)
+	   	}*/
+
+	marshalledJob, err := json.Marshal(job)
+
+	if err != nil {
+		logger.Error(err, "Marshalling job error.")
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	logger.Info("Admission job success.")
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshalledJob)
+}
+
+// Default is the expected entrypoint for a webhook
+func (a *fluenceWatcher) Default(ctx context.Context, obj runtime.Object) error {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		job, ok := obj.(*batchv1.Job)
+		if !ok {
+			return fmt.Errorf("expected a Pod or Job but got a %T", obj)
+		}
+		logger.Info(fmt.Sprintf("Job %s is marked for fluence.", job.Name))
+		return nil
+		//		return a.InjectJob(job)
+	}
+	logger.Info(fmt.Sprintf("Pod %s is marked for fluence.", pod.Name))
+	return nil
+	//return a.InjectPod(pod)
+}
+
+// InjectPod adds the sidecar container to a pod
+func (a *fluenceWatcher) InjectPod(pod *corev1.Pod) error {
+
+	/*
+		// Cut out early if we have no labels
+		if pod.Annotations == nil {
+			logger.Info(fmt.Sprintf("Pod %s is not marked for oras storage.", pod.Name))
+			return nil
+		}
+
+		// Parse oras known labels into settings
+		settings := orasSettings.NewOrasCacheSettings(pod.Annotations)
+
+		// Cut out early if no oras identifiers!
+		if !settings.MarkedForOras {
+			logger.Warnf("Pod %s is not marked for oras storage.", pod.Name)
+			return nil
+		}
+
+		// Validate, return error if no good here.
+		if !settings.Validate() {
+			logger.Warnf("Pod %s oras storage did not validate.", pod.Name)
+			return fmt.Errorf("oras storage was requested but is not valid")
+		}
+
+		// The selector for the namespaced registry is the namespace
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
+		}
+
+		// Even pods without say, the launcher, that are marked should have the network added
+		pod.Labels[defaults.OrasSelectorKey] = pod.ObjectMeta.Namespace
+		oras.AddSidecar(&pod.Spec, pod.ObjectMeta.Namespace, settings)
+		logger.Info(fmt.Sprintf("Pod %s is marked for oras storage.", pod.Name))*/
+	return nil
+}
+
+// InjectJob adds the sidecar container to the PodTemplateSpec of the Job
+func (a *fluenceWatcher) InjectJob(job *batchv1.Job) error {
+
+	/*
+		// Cut out early if we have no labels
+		if job.Annotations == nil {
+			logger.Info(fmt.Sprintf("Job %s is not marked for oras storage.", job.Name))
+			return nil
+		}
+
+		// Parse oras known labels into settings
+		settings := orasSettings.NewOrasCacheSettings(job.Annotations)
+
+		// Cut out early if no oras identifiers!
+		if !settings.MarkedForOras {
+			logger.Warnf("Job %s is not marked for oras storage.", job.Name)
+			return nil
+		}
+
+		// Validate, return error if no good here.
+		if !settings.Validate() {
+			logger.Warnf("Job %s oras storage did not validate.", job.Name)
+			return fmt.Errorf("oras storage was requested but is not valid")
+		}
+
+		// Add the sidecar to the podspec of the job
+		if job.Spec.Template.Labels == nil {
+			job.Spec.Template.Labels = map[string]string{}
+		}
+
+		// Add network to spec template so all pods are targeted
+		job.Spec.Template.Labels[defaults.OrasSelectorKey] = job.ObjectMeta.Namespace
+		oras.AddSidecar(&job.Spec.Template.Spec, job.ObjectMeta.Namespace, settings)
+		logger.Info(fmt.Sprintf("Job %s is marked for oras storage.", job.Name))*/
+	return nil
+}

--- a/sig-scheduler-plugins/cmd/controller/app/server.go
+++ b/sig-scheduler-plugins/cmd/controller/app/server.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2/klogr"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	api "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
+	"sigs.k8s.io/scheduler-plugins/pkg/controllers"
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	utilruntime.Must(api.AddToScheme(scheme))
+}
+
+func Run(s *ServerRunOptions) error {
+	config := ctrl.GetConfigOrDie()
+	config.QPS = float32(s.ApiServerQPS)
+	config.Burst = s.ApiServerBurst
+
+	// Controller Runtime Controllers
+	ctrl.SetLogger(klogr.New())
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                  scheme,
+		MetricsBindAddress:      s.MetricsAddr,
+		Port:                    9443,
+		HealthProbeBindAddress:  s.ProbeAddr,
+		LeaderElection:          s.EnableLeaderElection,
+		LeaderElectionID:        "sched-plugins-controllers",
+		LeaderElectionNamespace: "kube-system",
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		return err
+	}
+
+	if err = (&controllers.PodGroupReconciler{
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Workers: s.Workers,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "PodGroup")
+		return err
+	}
+
+	mgr.GetWebhookServer().Register("/mutate-v1-fluence", &webhook.Admission{
+		Handler: api.NewMutatingWebhook(mgr),
+	})
+
+	if err = (&controllers.ElasticQuotaReconciler{
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Workers: s.Workers,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ElasticQuota")
+		return err
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		return err
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		return err
+	}
+
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "unable to start manager")
+		return err
+	}
+	return nil
+}

--- a/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/crds/scheduling.x-k8s.io_podgroups.yaml
+++ b/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/crds/scheduling.x-k8s.io_podgroups.yaml
@@ -1,0 +1,108 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/scheduler-plugins/pull/50
+    controller-gen.kubebuilder.io/version: v0.11.1
+    # TODO this needs if .Vaues.enableCertManager added back
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ include "scheduler-plugins-as-a-second-scheduler.fullname" . }}-serving-cert'
+  creationTimestamp: null
+  name: podgroups.scheduling.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: scheduling.x-k8s.io
+  names:
+    kind: PodGroup
+    listKind: PodGroupList
+    plural: podgroups
+    shortNames:
+    - pg
+    - pgs
+    singular: podgroup
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PodGroup is a collection of Pod; used for batch workload.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior of the pod group.
+            properties:
+              minMember:
+                description: MinMember defines the minimal number of members/tasks
+                  to run the pod group; if there's not enough resources to start all
+                  tasks, the scheduler will not start anyone.
+                format: int32
+                type: integer
+              minResources:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: MinResources defines the minimal resource of members/tasks
+                  to run the pod group; if there's not enough resources to start all
+                  tasks, the scheduler will not start anyone.
+                type: object
+              scheduleTimeoutSeconds:
+                description: ScheduleTimeoutSeconds defines the maximal time of members/tasks
+                  to wait before run the pod group;
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status represents the current information about a pod group.
+              This data may not be up to date.
+            properties:
+              failed:
+                description: The number of pods which reached phase Failed.
+                format: int32
+                type: integer
+              occupiedBy:
+                description: OccupiedBy marks the workload (e.g., deployment, statefulset)
+                  UID that occupy the podgroup. It is empty if not initialized.
+                type: string
+              phase:
+                description: Current phase of PodGroup.
+                type: string
+              running:
+                description: The number of actively running pods.
+                format: int32
+                type: integer
+              scheduleStartTime:
+                description: ScheduleStartTime of the group
+                format: date-time
+                type: string
+              succeeded:
+                description: The number of pods which reached phase Succeeded.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+++ b/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
@@ -20,6 +20,19 @@ spec:
       - name: scheduler-plugins-controller
         image: {{ .Values.controller.image }}
         imagePullPolicy: {{ .Values.controller.pullPolicy }}
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/mutating-webhook-configuration.yaml
+++ b/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/mutating-webhook-configuration.yaml
@@ -1,0 +1,40 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "scheduler-plugins-as-a-second-scheduler.name" . }}-mutating-webhook-configuration
+  {{- if .Values.enableCertManager }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "scheduler-plugins-as-a-second-scheduler.fullname" . }}-serving-cert
+  {{- end}}
+  labels:
+  {{- include "scheduler-plugins-as-a-second-scheduler.labels" . | nindent 4 }}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: '{{ include "scheduler-plugins-as-a-second-scheduler.fullname" . }}-webhook-service'
+      namespace: '{{ .Release.Namespace }}'
+      path: /mutate-v1-fluence
+      {{- with (index .Values.webhookService.ports 0) }}
+      port: {{ .port }}
+      {{- end }}
+
+  failurePolicy: Fail
+  name: morascache.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    - core
+    - batch
+    - scheduling.x-k8s.io
+    apiVersions:
+    - v1
+    - v1alpha1
+    operations:
+    - CREATE
+    resources:
+    - pods
+    - jobs
+    - podgroups
+  sideEffects: None

--- a/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/selfsigned-issuer.yaml
+++ b/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/selfsigned-issuer.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.enableCertManager }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "scheduler-plugins-as-a-second-scheduler.fullname" . }}-selfsigned-issuer
+  labels:
+  {{- include "scheduler-plugins-as-a-second-scheduler.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+{{- end}}

--- a/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/serving-cert.yaml
+++ b/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/serving-cert.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.enableCertManager }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "scheduler-plugins-as-a-second-scheduler.fullname" . }}-serving-cert
+  labels:
+  {{- include "scheduler-plugins-as-a-second-scheduler.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+  - '{{ include "scheduler-plugins-as-a-second-scheduler.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc'
+  - '{{ include "scheduler-plugins-as-a-second-scheduler.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.{{
+    .Values.kubernetesClusterDomain }}'
+  issuerRef:
+    kind: Issuer
+    name: '{{ include "scheduler-plugins-as-a-second-scheduler.fullname" . }}-selfsigned-issuer'
+  secretName: webhook-server-cert
+{{- end}}

--- a/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/webhook-service.yaml
+++ b/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/webhook-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "scheduler-plugins-as-a-second-scheduler.fullname" . }}-webhook-service
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: scheduler-plugins-controller
+    app.kubernetes.io/part-of: scheduler-plugins-controller
+  {{- include "scheduler-plugins-as-a-second-scheduler.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.webhookService.type }}
+  selector:
+    app: scheduler-plugins-controller
+  ports:
+	{{- .Values.webhookService.ports | toYaml | nindent 2 -}}

--- a/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -21,7 +21,6 @@ scheduler:
 
 controller:
   name: scheduler-plugins-controller
-  image: registry.k8s.io/scheduler-plugins/controller:v0.27.8
   image: ghcr.io/flux-framework/fluence-controller:latest
   replicaCount: 1
   pullPolicy: IfNotPresent
@@ -45,3 +44,12 @@ pluginConfig:
 #   args:
 #     scoringStrategy:
 #       type: MostAllocated # default is LeastAllocated
+
+enableCertManager: true
+kubernetesClusterDomain: cluster.local
+webhookService:
+  ports:
+  - port: 9443
+    protocol: TCP
+    targetPort: 9443
+  type: ClusterIP


### PR DESCRIPTION
Problem: We want to try a design where a mutating admission webhook can handle receiving and creating PodGroup from labels. We are choosing mutating with the expectation that, at some point, we might be able to change the size  (min/max/desired) either for the PodGroup or some other watcher to jobs.

Solution: tiny steps to add a webhook.

Since this PR is going into #61 I am going to merge freely to continue work - I only separated it into a branch because (about 3 hours ago) when it was epically failing I realized I might need to try a different approach. Note that this is an empty skeleton - the webhook is added and running but basically doing nothing. Verified:

```console
 kubectl logs scheduler-plugins-controller-58767dcf99-sps4j | grep hook
I0217 22:46:40.206735       1 server.go:187] controller-runtime/webhook "msg"="Registering webhook" "path"="/mutate-v1-fluence"
I0217 22:46:40.206887       1 server.go:216] controller-runtime/webhook/webhooks "msg"="Starting webhook server" 
I0217 22:46:40.207281       1 server.go:273] controller-runtime/webhook "msg"="Serving webhook server" "host"="" "port"=9443
I0217 22:46:40.320180       1 elasticquota_controller.go:52]  "msg"="reconciling" "ElasticQuota"={"name":"cert-manager-webhook-869b6c65c4-c9tqr","namespace":"cert-manager"} "controller"="elasticquota" "controllerGroup"="scheduling.x-k8s.io" "controllerKind"="ElasticQuota" "name"="cert-manager-webhook-869b6c65c4-c9tqr" "namespace"="cert-manager" "reconcileID"="6bc7b577-9d3f-417d-8e23-52a7d141470a"
I0217 22:48:21.009266       1 podgroup_webhook.go:51] setup "msg"="Running webhook handle" 
I0217 22:48:21.011380       1 podgroup_webhook.go:97] setup "msg"="Admission job success." 
I0217 22:48:21.097234       1 podgroup_webhook.go:51] setup "msg"="Running webhook handle" 
I0217 22:48:21.098004       1 podgroup_webhook.go:78] setup "msg"="Admission pod success." 
I0217 22:48:21.165158       1 podgroup_webhook.go:51] setup "msg"="Running webhook handle" 
I0217 22:48:21.165695       1 podgroup_webhook.go:78] setup "msg"="Admission pod success." 
```

This does require adding the cert-manager, which is notoriously hairly. But I've gotten it working twice now, and know that kueue has a strategy to also allow a self signed certificate, so I prepared the templates anticipating that (but not added yet). There isn't really another way to have webhooks without some kind of certificate, afaik, so this is needed.

I am also addressing one more issue:

I noticed a bug while running fluence with kind (and multiple worker nodes) that fluence was assigning work to the control plane, and then we were in a stuck stack, because the control plane has a taint (or similar) that prevents that. I think there maybe used to be logic (a commented out worker label) that was anticipating doing a check for a control plane, but it was never added. I would guess because on production clusters we don't need it - deploying to GCP right now, I am aware a control plane exists but it's not any of the nodes that are given to me, which is interesting. 

Note that this addition does not guarantee this design will work, but it is just one step. Since the helm charts are manually generated for the scheduler-plugin (as far as I can tell) this took me almost 6 hours to figure out and get working. I am really starting to think there is no skill behind software engineering beyond absolute patience.