### PR TITLE
[WIP] fluence: refactor to use new PodGroup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# Development Notes
+
+## Thinking
+
+> Updated February 15, 2024
+
+What I think might be happening (and not always, sometimes)
+
+- New pod group, no node list
+- Fluence assigns nodes
+- Nodes get assigned to pods 1:1
+- POD group is deleted
+- Some pod is sent back to queue (kubelet rejects, etc)
+- POD group does not exist and is recreated, no node list
+- Fluence asks again, but still has the first job. Not enough resources, asks forever.
+
+The above would not happen with the persistent pod group (if it wasn't cleaned up until the deletion of the job) and wouldn't happen if there are just enough resources to account for the overlap.
+
+- Does Fluence allocate resources for itself?
+- It would be nice to be able to inspect the state of Fluence.
+- At some point we want to be using the TBA fluxion-go instead of the one off branch we currently have (but we don't need to be blocked for that)
+- We should (I think) restore pod group (it's in the controller here) and have our own container built. That way we have total control over the custom resource, and we don't risk it going away.
+  - As a part of that, we can add add a mutating webhook that emulates what we are doing in fluence now to find the label, but instead we will create the CRD to hold state instead of trying to hold in the operator.
+- It could then also be investigated that we can more flexibly change the size of the group, within some min/max size (also determined by labels?) to help with scheduling.
+- Note that kueue has added a Pod Group object, so probably addresses the static case here.

--- a/examples/simple_example/fluence-scheduler-pod.yaml
+++ b/examples/simple_example/fluence-scheduler-pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: fluence-scheduled-pod-1
+  name: fluence-scheduled-pod
   labels:
     name: scheduler-example
 spec:

--- a/sig-scheduler-plugins/pkg/fluence/events.go
+++ b/sig-scheduler-plugins/pkg/fluence/events.go
@@ -1,0 +1,150 @@
+package fluence
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+	v1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
+
+	pb "sigs.k8s.io/scheduler-plugins/pkg/fluence/fluxcli-grpc"
+)
+
+// Events are associated with inforers, typically on pods, e.g.,
+// delete: deletion of a pod
+// update: update of a pod!
+// For both of the above, there are cases to cancel the flux job
+//  associated with the group id
+
+// cancelFluxJobForPod cancels the flux job for a pod.
+// We assume that the cancelled job also means deleting the pod group
+func (f *Fluence) cancelFluxJob(groupName string) error {
+
+	jobid, ok := f.groupToJobId[groupName]
+
+	// The job was already cancelled by another pod
+	if !ok {
+		klog.Infof("[Fluence] Request for cancel of group %s is already complete.", groupName)
+		return nil
+	}
+	klog.Infof("[Fluence] Cancel flux job: %v for group %s", jobid, groupName)
+
+	// This first error is about connecting to the server
+	conn, err := grpc.Dial("127.0.0.1:4242", grpc.WithInsecure())
+	if err != nil {
+		klog.Errorf("[Fluence] Error connecting to server: %v", err)
+		return err
+	}
+	defer conn.Close()
+
+	grpcclient := pb.NewFluxcliServiceClient(conn)
+	_, cancel := context.WithTimeout(context.Background(), 200*time.Second)
+	defer cancel()
+
+	// This error reflects the success or failure of the cancel request
+	request := &pb.CancelRequest{JobID: int64(jobid)}
+	res, err := grpcclient.Cancel(context.Background(), request)
+	if err != nil {
+		klog.Errorf("[Fluence] did not receive any cancel response: %v", err)
+		return err
+	}
+	klog.Infof("[Fluence] Job cancellation for group %s result: %d", groupName, res.Error)
+
+	// And this error is if the cancel was successful or not
+	if res.Error == 0 {
+		klog.Infof("[Fluence] Successful cancel of flux job: %d for group %s", jobid, groupName)
+		delete(f.groupToJobId, groupName)
+	} else {
+		klog.Warningf("[Fluence] Failed to cancel flux job %d for group %s", jobid, groupName)
+	}
+	return nil
+}
+
+// updatePod is called on an update, and the old and new object are presented
+func (f *Fluence) updatePod(oldObj, newObj interface{}) {
+
+	oldPod := oldObj.(*v1.Pod)
+	newPod := newObj.(*v1.Pod)
+
+	// a pod is updated, get the group
+	// TODO should we be checking group / size for old vs new?
+	groupName, _ := f.pgMgr.GetPodGroup(context.TODO(), oldPod)
+
+	klog.Infof("[Fluence] Processing event for pod %s in group %s from %s to %s", newPod.Name, groupName, newPod.Status.Phase, oldPod.Status.Phase)
+
+	switch newPod.Status.Phase {
+	case v1.PodPending:
+		// in this state we don't know if a pod is going to be running, thus we don't need to update job map
+	case v1.PodRunning:
+		// if a pod is start running, we can add it state to the delta graph if it is scheduled by other scheduler
+	case v1.PodSucceeded:
+		klog.Infof("[Fluence] Pod %s succeeded, Fluence needs to free the resources", newPod.Name)
+
+		f.mutex.Lock()
+		defer f.mutex.Unlock()
+
+		// Do we have the group id in our cache? If yes, we haven't deleted the jobid yet
+		// I am worried here that if some pods are succeeded and others pending, this could
+		// be a mistake - fluence would schedule it again
+		_, ok := f.groupToJobId[groupName]
+		if ok {
+			f.cancelFluxJob(groupName)
+		} else {
+			klog.Infof("[Fluence] Succeeded pod %s/%s in group %s doesn't have flux jobid", newPod.Namespace, newPod.Name, groupName)
+		}
+
+	case v1.PodFailed:
+
+		// a corner case need to be tested, the pod exit code is not 0, can be created with segmentation fault pi test
+		klog.Warningf("[Fluence] Pod %s in group %s failed, Fluence needs to free the resources", newPod.Name, groupName)
+
+		f.mutex.Lock()
+		defer f.mutex.Unlock()
+
+		_, ok := f.groupToJobId[groupName]
+		if ok {
+			f.cancelFluxJob(groupName)
+		} else {
+			klog.Errorf("[Fluence] Failed pod %s/%s in group %s doesn't have flux jobid", newPod.Namespace, newPod.Name, groupName)
+		}
+	case v1.PodUnknown:
+		// don't know how to deal with it as it's unknown phase
+	default:
+		// shouldn't enter this branch
+	}
+}
+
+// deletePod handles the delete event handler
+func (f *Fluence) deletePod(podObj interface{}) {
+	klog.Info("[Fluence] Delete Pod event handler")
+	pod := podObj.(*v1.Pod)
+	groupName, _ := f.pgMgr.GetPodGroup(context.TODO(), pod)
+
+	klog.Infof("[Fluence] Delete pod %s in group %s has status %s", pod.Status.Phase, pod.Name, groupName)
+	switch pod.Status.Phase {
+	case v1.PodSucceeded:
+	case v1.PodPending:
+		klog.Infof("[Fluence] Pod %s completed and is Pending termination, Fluence needs to free the resources", pod.Name)
+
+		f.mutex.Lock()
+		defer f.mutex.Unlock()
+
+		_, ok := f.groupToJobId[groupName]
+		if ok {
+			f.cancelFluxJob(groupName)
+		} else {
+			klog.Infof("[Fluence] Terminating pod %s/%s in group %s doesn't have flux jobid", pod.Namespace, pod.Name, groupName)
+		}
+	case v1.PodRunning:
+		f.mutex.Lock()
+		defer f.mutex.Unlock()
+
+		_, ok := f.groupToJobId[groupName]
+		if ok {
+			f.cancelFluxJob(groupName)
+		} else {
+			klog.Infof("[Fluence] Deleted pod %s/%s in group %s doesn't have flux jobid", pod.Namespace, pod.Name, groupName)
+		}
+	}
+}

--- a/sig-scheduler-plugins/pkg/fluence/group/group.go
+++ b/sig-scheduler-plugins/pkg/fluence/group/group.go
@@ -1,103 +1,23 @@
 package group
 
 import (
-	"fmt"
-	"strconv"
-
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
-	fcore "sigs.k8s.io/scheduler-plugins/pkg/fluence/core"
-	"sigs.k8s.io/scheduler-plugins/pkg/fluence/labels"
+	sched "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 )
 
-// getDefaultGroupName returns a group name based on the pod namespace and name
-// We could do this for pods that are not labeled, and treat them as a size 1 group
-func getDefaultGroupName(pod *v1.Pod) string {
-	return fmt.Sprintf("%s-%s", pod.Namespace, pod.Name)
-}
-
-// getPodsGroup gets the pods group, if it exists.
-func GetPodsGroup(pod *v1.Pod) *fcore.PodGroupCache {
-	groupName := EnsureFluenceGroup(pod)
-	return fcore.GetPodGroup(groupName)
-}
-
-// GetGroup is a courtesy wrapper around fcore.GetPodGroup
-func GetGroup(groupName string) *fcore.PodGroupCache {
-	return fcore.GetPodGroup(groupName)
-}
-
-// ensureFluenceGroup ensure that a podGroup is created for the named fluence group
-// Preference goes to the traditional PodGroup (created by the user)
-// and falls back to having one created by fluence. If there is no PodGroup
-// created and no fluence annotation, we do not create the group.
-// Likely for fluence we'd want a cleanup function somehow too,
-// for now assume groups are unique by name.
-func EnsureFluenceGroup(pod *v1.Pod) string {
-
-	// Get the group name and size from the fluence labels
-	groupName := getFluenceGroupName(pod)
-	groupSize := getFluenceGroupSize(pod)
-
-	// If there isn't a group, make a single node sized group
-	// This is so we can always treat the cases equally
-	if groupName == "" {
-		klog.Infof("[Fluence] Group annotation missing for pod %s", pod.Name)
-		groupName = getDefaultGroupName(pod)
-	}
-	klog.Infof("[Fluence] Group name for %s is %s", pod.Name, groupName)
-	klog.Infof("[Fluence] Group size for %s is %d", pod.Name, groupSize)
-
-	// Register the pod group (with the pod) in our cache
-	fcore.RegisterPodGroup(pod, groupName, groupSize)
-	return groupName
-}
-
-// deleteFluenceGroup ensures the pod group is deleted, if it exists
-func DeleteFluenceGroup(pod *v1.Pod) {
-	// Get the group name and size from the fluence labels
-	pg := GetPodsGroup(pod)
-	fcore.DeletePodGroup(pg.Name)
-	klog.Infof("[Fluence] known groups are:\n")
-	fcore.ListGroups()
-}
-
-// getFluenceGroupName looks for the group to indicate a fluence group, and returns it
-func getFluenceGroupName(pod *v1.Pod) string {
-	groupName, _ := pod.Labels[labels.PodGroupLabel]
-	return groupName
-}
-
-// getFluenceGroupSize gets the size of the fluence group
-func getFluenceGroupSize(pod *v1.Pod) int32 {
-	size, _ := pod.Labels[labels.PodGroupSizeLabel]
-
-	// Default size of 1 if the label is not set (but name is)
-	if size == "" {
-		return 1
-	}
-
-	// We don't want the scheduler to fail if someone puts a value for size
-	// that doesn't convert nicely. They can find this in the logs.
-	intSize, err := strconv.ParseUint(size, 10, 32)
-	if err != nil {
-		klog.Error("   [Fluence] Parsing integer size for pod group")
-	}
-	return int32(intSize)
-}
-
 // GetCreationTimestamp first tries the fluence group, then falls back to the initial attempt timestamp
-func GetCreationTimestamp(groupName string, podInfo *framework.QueuedPodInfo) metav1.MicroTime {
-	pg := fcore.GetPodGroup(groupName)
+// This is the only update we have made to the upstream PodGroupManager, because we are expecting
+// a MicroTime and not a time.Time.
+func GetCreationTimestamp(groupName string, pg *sched.PodGroup, podInfo *framework.QueuedPodInfo) metav1.MicroTime {
 
 	// IsZero is an indicator if this was actually set
 	// If the group label was present and we have a group, this will be true
-	if !pg.TimeCreated.IsZero() {
-		klog.Infof("   [Fluence] Pod group %s was created at %s\n", groupName, pg.TimeCreated)
-		return pg.TimeCreated
+	if !pg.Status.ScheduleStartTime.IsZero() {
+		klog.Infof("   [Fluence] Pod group %s was created at %s\n", groupName, pg.Status.ScheduleStartTime)
+		return pg.Status.ScheduleStartTime
 	}
 	// We should actually never get here.
 	klog.Errorf("   [Fluence] Pod group %s time IsZero, we should not have reached here", groupName)

--- a/sig-scheduler-plugins/pkg/fluence/utils/utils.go
+++ b/sig-scheduler-plugins/pkg/fluence/utils/utils.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 	pb "sigs.k8s.io/scheduler-plugins/pkg/fluence/fluxcli-grpc"
 )
 
@@ -39,12 +39,14 @@ func getPodJobspecLabels(pod *v1.Pod) []string {
 	return labels
 }
 
-// InspectPodInfo takes a pod object and returns the pod.spec
-// Note from vsoch - I updated this to calculate containers across the pod
-// if that's wrong we can change it back.
-func InspectPodInfo(pod *v1.Pod) *pb.PodSpec {
+// PreparePodJobSpec takes a pod object and returns the jobspec
+// The jobspec is based on the pod, and assumes it will be duplicated
+// for a MatchAllocate request (representing all pods). We name the
+// jobspec based on the group and not the individual ID.
+// This calculates across containers in the od
+func PreparePodJobSpec(pod *v1.Pod, groupName string) *pb.PodSpec {
 	ps := new(pb.PodSpec)
-	ps.Id = pod.Name
+	ps.Id = groupName
 
 	// Note from vsoch - there was an if check here to see if we had labels,
 	// I don't think there is risk to adding an empty list but we can add

--- a/src/fluence/fluxion/fluxion.go
+++ b/src/fluence/fluxion/fluxion.go
@@ -8,7 +8,7 @@ import (
 	"github.com/flux-framework/flux-k8s/flux-plugin/fluence/jobspec"
 	"github.com/flux-framework/flux-k8s/flux-plugin/fluence/utils"
 	"github.com/flux-framework/fluxion-go/pkg/fluxcli"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"context"
 	"errors"


### PR DESCRIPTION
Problem: fluence should only be storing state of jobid and presence of a group name in a map to indicate node assignment. Soluion: update the code here. Note that this is not working yet, and I am pushing / opening the PR to not use the work (and will update accordingly, and using this PR to test).

Going for a run, will continue debugging when I get back. There is a bug somewhere where we aren't asking, and the map is empty - likely in the PreFilter function I missed something.