### PR TITLE
feat: add support for other abstractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ spec:
   backoffLimit: 4
 ```
 
-There is no reason pods with different names or under different abstractions cannot be part of the same group that needs to be scheduled together.
+There is no reason pods with different names or under different abstractions cannot be part of the same group that needs to be scheduled together. Also note that:
+
+- We currently do not allow scheduling to a control plane
+- Deployments, StatefulSets, and ReplicaSets can be scheduled and have pod groups created, however the pod groups are not cleaned up as these abstractions are not meant to complete.
 
 ### Deploy
 
@@ -520,7 +523,8 @@ kind create cluster --config ./kind-config.yaml
 #### TODO
 
  - Try what [kueue does](https://github.com/kubernetes-sigs/kueue/blob/6d57813a52066dab412735deeeb60ebb0cdb8e8e/cmd/kueue/main.go#L146-L155) to not require cert-manager.
- - Add other abstraction types to be intercepted (and labeled with sizes)
+ - Try other strategies for setting owner references (so cleans up when owner deleted)
+   - When that is done, add tests for deletion of pod group (the current method is not perfect and needs improvement)
 
 #### Components
 

--- a/examples/simple_example/fluence-deployment.yaml
+++ b/examples/simple_example/fluence-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-deployment
+spec:
+  selector:
+    matchLabels:
+      app: example-deployment
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: example-deployment
+    spec:
+      schedulerName: fluence 
+      containers:
+      - name: example
+        image: rockylinux:9
+        command: ["sleep", "infinity"]

--- a/examples/simple_example/fluence-replicaset.yaml
+++ b/examples/simple_example/fluence-replicaset.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: example-replicaset
+  labels:
+    app: example-replicaset
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: example-replicaset
+  template:
+    metadata:
+      labels:
+        app: example-replicaset
+    spec:
+      schedulerName: fluence 
+      containers:
+      - name: example
+        image: rockylinux:9
+        command: ["sleep", "infinity"]

--- a/examples/simple_example/fluence-statefulset.yaml
+++ b/examples/simple_example/fluence-statefulset.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: example-statefulset
+  labels:
+    app: example-statefulset
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: example-statefulset
+  template:
+    metadata:
+      labels:
+        app: example-statefulset
+    spec:
+      schedulerName: fluence 
+      containers:
+      - name: example
+        image: rockylinux:9
+        command: ["sleep", "infinity"]

--- a/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/mutating-webhook-configuration.yaml
+++ b/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/mutating-webhook-configuration.yaml
@@ -26,6 +26,7 @@ webhooks:
   - apiGroups:
     - ""
     - core
+    - apps
     - batch
     - scheduling.x-k8s.io
     apiVersions:
@@ -36,6 +37,10 @@ webhooks:
     resources:
     - pods
     - jobs
+    - statefulsets
+    - deployments
+    - replicasets
+
 # Can uncomment this if we want to mutate the pod groups after creation
 #    - podgroups
   sideEffects: None

--- a/sig-scheduler-plugins/pkg/controllers/podgroup_controller.go
+++ b/sig-scheduler-plugins/pkg/controllers/podgroup_controller.go
@@ -123,7 +123,7 @@ func (r *PodGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// TODO: Not clear what to do here. Arguably, we also want to check the label size
 		// because (in the future) we can accept smaller sizes. But then we also need
 		// to account for if the labels are different, do we take the smallest?
-		log.Info("PodGroup", "Status", fmt.Sprintf("WARNING: Pod group current MinMember %s does not match %d", pg.Spec.MinMember, size))
+		log.Info("PodGroup", "Status", fmt.Sprintf("WARNING: Pod group current MinMember %d does not match %d", pg.Spec.MinMember, size))
 	}
 	return r.updateStatus(ctx, pg, podList.Items)
 
@@ -192,6 +192,8 @@ func (r *PodGroupReconciler) updateStatus(
 
 	// Apply the patch to update, or delete if finished
 	// TODO would be better if owner references took here, so delete on owner deletion
+	// TODO deletion is not currently handled for Deployment, ReplicaSet, StatefulSet
+	// as they are expected to persist. You can delete / lose and bring up again
 	var err error
 	if pg.Status.Phase == schedv1alpha1.PodGroupFinished || pg.Status.Phase == schedv1alpha1.PodGroupFailed {
 		err = r.Delete(ctx, pg)

--- a/sig-scheduler-plugins/pkg/fluence/group/group.go
+++ b/sig-scheduler-plugins/pkg/fluence/group/group.go
@@ -1,6 +1,9 @@
 package group
 
 import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klog "k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -8,10 +11,28 @@ import (
 	sched "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 )
 
+// CreateFakeGroup wraps an arbitrary pod in a fake group for fluence to schedule
+// This happens only in PreFilter so we already sorted
+func CreateFakeGroup(pod *corev1.Pod) *sched.PodGroup {
+	groupName := fmt.Sprintf("fluence-solo-%s-%s", pod.Namespace, pod.Name)
+	return &sched.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      groupName,
+			Namespace: pod.Namespace,
+		},
+		Spec: sched.PodGroupSpec{MinMember: int32(1)},
+	}
+}
+
 // GetCreationTimestamp first tries the fluence group, then falls back to the initial attempt timestamp
 // This is the only update we have made to the upstream PodGroupManager, because we are expecting
 // a MicroTime and not a time.Time.
 func GetCreationTimestamp(groupName string, pg *sched.PodGroup, podInfo *framework.QueuedPodInfo) metav1.MicroTime {
+
+	// Don't try to get a time for a pod group that does not exist
+	if pg == nil {
+		return metav1.NewMicroTime(*podInfo.InitialAttemptTimestamp)
+	}
 
 	// IsZero is an indicator if this was actually set
 	// If the group label was present and we have a group, this will be true


### PR DESCRIPTION
Problem: we need to be able to run deployments, stateful/replica sets and have them handled by fluence.
Solution: allow the webhook to create pod groups for them. In the case they are not targeted for fluence (any abstraction) and get into the PreFilter, allow creation of a FauxPodGroup that will simply schedule one job for the pod. We do this twice - in PreFilter and in the events for update/delete.