### PR TITLE
testing: gke then eks

### DIFF
--- a/sig-scheduler-plugins/pkg/fluence/events.go
+++ b/sig-scheduler-plugins/pkg/fluence/events.go
@@ -22,6 +22,9 @@ import (
 // We assume that the cancelled job also means deleting the pod group
 func (f *Fluence) cancelFluxJob(groupName string) error {
 
+	// TODO: it's a bit risky to store state here, because if the scheduler
+	// restarts we cannot look up the jobid, and then cannot cancel it.
+	// There is no way to request cancelling the job for a specific group
 	jobid, ok := f.groupToJobId[groupName]
 
 	// The job was already cancelled by another pod


### PR DESCRIPTION
I am making small changes as I test on GKE and EKS. My first tests on GKE had me creating / deleting jobs, and I think the state of fluence (fluxion) got out of sync with the jobs, meaning that fluxion thought jobs were running that were not and then was unable to allocate new ones. To adjust for that we can add back in the cancel response, but this will only work given that fluence has not lost memory of the job id. We likely need an approach that can either save the jobids to the state data (that could be reloaded) or a way to inspect jobs explicitly and purge, OR (better) a way to look up a job not based on the id, but based on the group id (the command in the jobspec). That way, regardless of a jobid, we could lose all of our state and still find the old (stale) job to delete. With a fresh state and larger cluster I am able to run jobs on GKE, but they are enormously slow - lammps size 2 2 2 is taking over 20 minutes. This is not the fault of fluence - GKE networking sucks. To keep debugging I likely need to move over to AWS with EFA, of course that introduces more things to figure out like EFA, etc.