### PR TITLE
test: adding permit to allow for sibling pod scheduling

### DIFF
--- a/examples/pod-group-jobs/job1.yaml
+++ b/examples/pod-group-jobs/job1.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: s0
+spec:
+  clusterIP: None
+  selector:
+    job-name: job-0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # name will be derived based on iteration
+  name: job-0
+spec:
+  completions: 4
+  parallelism: 4
+  completionMode: Indexed
+  template:
+    metadata:
+      labels:
+        app: job-0        
+    spec:
+      subdomain: s0
+      schedulerName: fluence
+      restartPolicy: Never
+      containers:
+      - name: example-workload
+        image: bash:latest
+        resources:
+          limits:
+            cpu: "3"
+          requests:
+            cpu: "3"
+        command:
+        - bash
+        - -c
+        - |
+          if [ $JOB_COMPLETION_INDEX -ne "0" ]
+            then
+              sleep infinity
+          fi
+          echo "START: $(date +%s)"
+          for i in 0 1 2 3
+          do
+            gotStatus="-1"
+            wantStatus="0"             
+            while [ $gotStatus -ne $wantStatus ]
+            do                      
+              ping -c 1 job-0-${i}.s0 > /dev/null 2>&1
+              gotStatus=$?                
+              if [ $gotStatus -ne $wantStatus ]; then
+                echo "Failed to ping pod job-0-${i}.s0, retrying in 1 second..."
+                sleep 1
+              fi
+            done                                                         
+            echo "Successfully pinged pod: job-0-${i}.s0"
+          done
+          echo "DONE: $(date +%s)"

--- a/examples/pod-group-jobs/job2.yaml
+++ b/examples/pod-group-jobs/job2.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: s1
+spec:
+  clusterIP: None
+  selector:
+    job-name: job-1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # name will be derived based on iteration
+  name: job-1
+spec:
+  completions: 4
+  parallelism: 4
+  completionMode: Indexed
+  template:
+    metadata:
+      labels:
+        app: job-1
+    spec:
+      subdomain: s1
+      schedulerName: fluence
+      restartPolicy: Never
+      containers:
+      - name: example-workload
+        image: bash:latest
+        resources:
+          limits:
+            cpu: "3"
+          requests:
+            cpu: "3"
+        command:
+        - bash
+        - -c
+        - |
+          if [ $JOB_COMPLETION_INDEX -ne "0" ]
+            then
+              sleep infinity
+          fi
+          echo "START: $(date +%s)"
+          for i in 0 1 2 3
+          do
+            gotStatus="-1"
+            wantStatus="0"             
+            while [ $gotStatus -ne $wantStatus ]
+            do                      
+              ping -c 1 job-0-${i}.s1 > /dev/null 2>&1
+              gotStatus=$?    
+              if [ $gotStatus -ne $wantStatus ]; then
+                echo "Failed to ping pod job-0-${i}.s1, retrying in 1 second..."
+                sleep 1
+              fi
+            done                                                         
+            echo "Successfully pinged pod: job-0-${i}.s1"
+          done
+          echo "DONE: $(date +%s)"

--- a/sig-scheduler-plugins/cmd/controller/app/server.go
+++ b/sig-scheduler-plugins/cmd/controller/app/server.go
@@ -27,6 +27,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	api "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 	"sigs.k8s.io/scheduler-plugins/pkg/controllers"
 )
@@ -50,9 +51,10 @@ func Run(s *ServerRunOptions) error {
 	// Controller Runtime Controllers
 	ctrl.SetLogger(klogr.New())
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                  scheme,
-		MetricsBindAddress:      s.MetricsAddr,
-		Port:                    9443,
+		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: s.MetricsAddr,
+		},
 		HealthProbeBindAddress:  s.ProbeAddr,
 		LeaderElection:          s.EnableLeaderElection,
 		LeaderElectionID:        "sched-plugins-controllers",

--- a/sig-scheduler-plugins/pkg/fluence/core/core.go
+++ b/sig-scheduler-plugins/pkg/fluence/core/core.go
@@ -293,6 +293,7 @@ func (pgMgr *PodGroupManager) PreFilter(
 	// it may not necessarily pass Filter due to other constraints such as affinity/taints.
 	_, ok := pgMgr.permittedPG.Get(pgFullName)
 	if ok {
+		pgMgr.log.Info("[PodGroup PreFilter] Pod Group %s is already admitted", pgFullName)
 		return nil
 	}
 

--- a/sig-scheduler-plugins/pkg/fluence/fluence.go
+++ b/sig-scheduler-plugins/pkg/fluence/fluence.go
@@ -67,7 +67,8 @@ var (
 
 	_ framework.EnqueueExtensions = &Fluence{}
 
-	permitWaitingTimeSeconds int64 = 60
+	// Set to be the same as coscheduling
+	permitWaitingTimeSeconds int64 = 300
 	podGroupBackoffSeconds   int64 = 0
 )
 
@@ -77,7 +78,7 @@ const (
 )
 
 // Initialize and return a new Fluence Custom Scheduler Plugin
-func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) {
+func New(_ context.Context, obj runtime.Object, handle framework.Handle) (framework.Plugin, error) {
 
 	ctx := context.TODO()
 

--- a/sig-scheduler-plugins/pkg/logger/logger.go
+++ b/sig-scheduler-plugins/pkg/logger/logger.go
@@ -79,8 +79,8 @@ func (l *DebugLogger) log(level int, prefix string, message ...any) error {
 	rest := message[1:]
 
 	//	msg := fmt.Sprintf(message...)
-	fmt.Printf("Compariing level %d >= %d\n", level, l.level)
-	if level >= l.level {
+	fmt.Printf("Compariing level %d <= %d\n", level, l.level)
+	if level <= l.level {
 		logger.Printf(prolog, rest...)
 	}
 	return l.Stop()

--- a/src/build/scheduler/Dockerfile
+++ b/src/build/scheduler/Dockerfile
@@ -2,11 +2,11 @@ FROM fluxrm/flux-sched:jammy
 
 USER root
 ENV DEBIAN_FRONTEND=noninteractive
-ENV GO_VERSION=1.19.10
+ENV GO_VERSION=1.21.9
 
 RUN apt-get update && apt-get clean -y && apt -y autoremove
 
-# Install go 19.10
+# Install go
 RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz  && tar -xvf go${GO_VERSION}.linux-amd64.tar.gz && \
     mv go /usr/local && rm go${GO_VERSION}.linux-amd64.tar.gz
 

--- a/src/fluence/go.mod
+++ b/src/fluence/go.mod
@@ -1,9 +1,9 @@
 module github.com/flux-framework/flux-k8s/flux-plugin/fluence
 
-go 1.19
+go 1.21
 
 require (
-	github.com/flux-framework/fluxion-go v0.32.0
+	github.com/flux-framework/fluxion-go v0.32.1-0.20240420052153-909523c84ca2
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/src/fluence/go.sum
+++ b/src/fluence/go.sum
@@ -100,6 +100,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flux-framework/fluxion-go v0.32.0 h1:NY6Y1mlTTTZhHD+CmAsDsdNTxUsAFDQoORpMZj8NFLI=
 github.com/flux-framework/fluxion-go v0.32.0/go.mod h1:ZI3QxSvUfgJE2Snur/SntJmVfpMjr6D4ICVmdqJ9fkQ=
+github.com/flux-framework/fluxion-go v0.32.1-0.20240420052153-909523c84ca2 h1:Yz/vVX0XfB2q51ZLh2p8YI5vphvv0rZF4PqtKPscvsY=
+github.com/flux-framework/fluxion-go v0.32.1-0.20240420052153-909523c84ca2/go.mod h1:jA5+kOSLxchFzixzYEvMAGjkXB5yszO/HxUwdhX/5/U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
Problem: the submit of the first index works for more controlled lengths (e.g., lammps takes a while) but was having issues with really quick jobs.
Solution: try restoring the queue that allows for enabling siblings pods so any group can be scheduled.