### PR TITLE
chore: rename utils to podspec

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: ^1.19
+        go-version: ^1.21
 
     - name: Build Containers
       run: |
@@ -57,7 +57,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: ^1.19
+        go-version: ^1.21
 
     - name: Build Containers
       run: |
@@ -94,7 +94,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: ^1.19
+        go-version: ^1.21
 
     - name: Build Container
       run: |

--- a/sig-scheduler-plugins/pkg/fluence/core/flux.go
+++ b/sig-scheduler-plugins/pkg/fluence/core/flux.go
@@ -10,7 +10,7 @@ import (
 	fgroup "sigs.k8s.io/scheduler-plugins/pkg/fluence/group"
 
 	"sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
-	"sigs.k8s.io/scheduler-plugins/pkg/fluence/utils"
+	"sigs.k8s.io/scheduler-plugins/pkg/fluence/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -47,7 +47,7 @@ func (podGroupManager *PodGroupManager) AskFlux(
 	// IMPORTANT: this is a JobSpec for *one* pod, assuming they are all the same.
 	// This obviously may not be true if we have a hetereogenous PodGroup.
 	// We name it based on the group, since it will represent the group
-	jobspec := utils.PreparePodJobSpec(&pod, groupName)
+	jobspec := podspec.PreparePodJobSpec(&pod, groupName)
 	podGroupManager.log.Info("[PodGroup AskFlux] Inspect pod info, jobspec: %s\n", jobspec)
 	conn, err := grpc.Dial("127.0.0.1:4242", grpc.WithInsecure())
 

--- a/sig-scheduler-plugins/pkg/fluence/podspec/podspec.go
+++ b/sig-scheduler-plugins/pkg/fluence/podspec/podspec.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package podspec
 
 import (
 	"strings"

--- a/src/build/scheduler/Dockerfile
+++ b/src/build/scheduler/Dockerfile
@@ -22,7 +22,7 @@ RUN apt -y update && apt -y upgrade && apt install --no-install-recommends -y pr
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
 
 # These need to be on the LD_LIBRARY_PATH for the server to find at runtime
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/lib:/usr/lib/flux
+ENV LD_LIBRARY_PATH=/usr/lib:/usr/lib/flux
 WORKDIR /go/src/fluence/
 COPY fluence Makefile /go/src/fluence/
 


### PR DESCRIPTION
Problem: the "utils" package in fluence does not describe what it does, and these functions are hard for the developer to find.
Solution: rename to podspec to reflect this is what the package is oriented to do.

This will close #77 