### PR TITLE
version: update builds and CI to go 1.22

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -55,7 +55,7 @@ default_job_pod=$(kubectl get pods --selector=job-name=default-job -o json | jq 
 echo
 echo "Fluence job pod is ${fluence_job_pod}"
 echo "Default job pod is ${default_job_pod}"
-sleep 10
+sleep 30
 
 # Shared function to check output
 function check_output {

--- a/.github/test.sh
+++ b/.github/test.sh
@@ -55,7 +55,7 @@ default_job_pod=$(kubectl get pods --selector=job-name=default-job -o json | jq 
 echo
 echo "Fluence job pod is ${fluence_job_pod}"
 echo "Default job pod is ${default_job_pod}"
-sleep 30
+sleep 10
 
 # Shared function to check output
 function check_output {

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: ^1.21
+        go-version: ^1.22
 
     - name: Build Containers
       run: |
@@ -57,7 +57,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: ^1.21
+        go-version: ^1.22
 
     - name: Build Containers
       run: |
@@ -94,7 +94,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: ^1.21
+        go-version: ^1.22
 
     - name: Build Container
       run: |

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: ^1.21
+        go-version: ^1.22
 
     - name: Build Containers
       run: |
@@ -56,7 +56,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: ^1.21
+        go-version: ^1.22
 
     - name: Build Container
       run: |
@@ -87,7 +87,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: ^1.21
+        go-version: ^1.22
 
     - name: Download fluence artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: ^1.21
+        go-version: ^1.22
 
     - name: Run Tests
       run: |

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PLATFORMS ?= linux/amd64
 BUILDER ?= docker
 
 # We match this to the fluence build (see src/build/scheduler/Dockerfile)
-GO_VERSION ?= 1.21.9
+GO_VERSION ?= 1.22.0
 GO_BASE_IMAGE ?= golang:${GO_VERSION}
 DISTROLESS_BASE_IMAGE ?= gcr.io/distroless/static:nonroot
 

--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,20 @@ prepare: clone
 	cp sig-scheduler-plugins/apis/scheduling/v1alpha1/*.go $(CLONE_UPSTREAM)/apis/scheduling/v1alpha1/
 	cp sig-scheduler-plugins/cmd/controller/app/server.go $(CLONE_UPSTREAM)/cmd/controller/app/server.go
 
+# This logic was moved from upstream/hack/build-images.sh - too much changing logic
+# and became hard to maintain
 build: prepare
 	echo ${GO_BASE_IMAGE}
-	BUILDER=${BUILDER} PLATFORMS=${PLATFORMS} REGISTRY=${REGISTRY} IMAGE=${SCHEDULER_IMAGE} \
-	CONTROLLER_IMAGE=${CONTROLLER_IMAGE} RELEASE_VERSION=${RELEASE_VERSION} \
-	GO_BASE_IMAGE=${GO_BASE_IMAGE} DISTROLESS_BASE_IMAGE=${DISTROLESS_BASE_IMAGE} \
-	$(BASH) $(CLONE_UPSTREAM)/hack/build-images.sh
+
+	docker build -f $(CLONE_UPSTREAM)/build/scheduler/Dockerfile --build-arg RELEASE_VERSION=${RELEASE_VERSION} \
+	--build-arg GO_BASE_IMAGE=${GO_BASE_IMAGE} \
+	--build-arg DISTROLESS_BASE_IMAGE=${DISTROLESS_BASE_IMAGE} \
+	--build-arg CGO_ENABLED=0 -t ${REGISTRY}/${SCHEDULER_IMAGE} $(CLONE_UPSTREAM)
+
+	docker build -f $(CLONE_UPSTREAM)/build/controller/Dockerfile --build-arg RELEASE_VERSION=${RELEASE_VERSION} \
+	--build-arg GO_BASE_IMAGE=${GO_BASE_IMAGE} \
+	--build-arg DISTROLESS_BASE_IMAGE=${DISTROLESS_BASE_IMAGE} \
+	--build-arg CGO_ENABLED=0 -t ${REGISTRY}/${CONTROLLER_IMAGE} $(CLONE_UPSTREAM)
 
 push-sidecar:
 	$(DOCKER) push $(REGISTRY)/$(SIDECAR_IMAGE):$(TAG) --all-tags

--- a/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+++ b/sig-scheduler-plugins/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           - containerPort: {{ .Values.scheduler.port }}
             hostPort: {{ .Values.scheduler.port }}{{ end }}
       - command:
-        - /kube-scheduler
+        - /bin/kube-scheduler
         - --config=/etc/kubernetes/scheduler-config.yaml
         - -v={{ .Values.scheduler.loggingLevel }}
         image: {{ .Values.scheduler.image }}

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,8 +4,7 @@ INSTALL_PREFIX ?= /usr
 LIB_PREFIX ?= /usr/lib
 LOCALBIN ?= $(shell pwd)/bin
 COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z)
-#BUILDENVVAR=CGO_CFLAGS="-I${FLUX_SCHED_ROOT}/resource/reapi/bindings/c" CGO_LDFLAGS="-L${INSTALL_PREFIX}/lib -L${FLUX_SCHED_ROOT}/resource -lresource -L${FLUX_SCHED_ROOT}/resource/libjobspec -ljobspec_conv -L/${FLUX_SCHED_ROOT}/resource/reapi/bindings -lreapi_cli -lflux-idset -lstdc++ -ljansson -lhwloc -lboost_system -lflux-hostlist -lboost_graph -lyaml-cpp"
-BUILDENVVAR=CGO_CFLAGS="-I${FLUX_SCHED_ROOT} -I${FLUX_SCHED_ROOT}/resource/reapi/bindings/c" CGO_LDFLAGS="-L${LIB_PREFIX} -L${LIB_PREFIX}/flux -L${FLUX_SCHED_ROOT}/resource/reapi/bindings -lreapi_cli -lflux-idset -lstdc++ -ljansson -lhwloc -lboost_system -lflux-hostlist -lboost_graph -lyaml-cpp"
+BUILDENVVAR=CGO_CFLAGS="-I${FLUX_SCHED_ROOT} -I${FLUX_SCHED_ROOT}/resource/reapi/bindings/c" CGO_LDFLAGS="-L${LIB_PREFIX} -L${LIB_PREFIX}/flux -L${FLUX_SCHED_ROOT}/resource/reapi/bindings -lreapi_cli -lflux-idset -lstdc++ -ljansson -lhwloc -lflux-hostlist -lboost_graph -lyaml-cpp"
 
 
 LOCAL_REGISTRY=localhost:5000

--- a/src/build/scheduler/Dockerfile
+++ b/src/build/scheduler/Dockerfile
@@ -2,7 +2,7 @@ FROM fluxrm/flux-sched:jammy
 
 USER root
 ENV DEBIAN_FRONTEND=noninteractive
-ENV GO_VERSION=1.21.9
+ENV GO_VERSION=1.22.0
 
 RUN apt-get update && apt-get clean -y && apt -y autoremove
 

--- a/src/fluence/go.mod
+++ b/src/fluence/go.mod
@@ -1,6 +1,6 @@
 module github.com/flux-framework/flux-k8s/flux-plugin/fluence
 
-go 1.21
+go 1.22
 
 require (
 	github.com/flux-framework/fluxion-go v0.32.1-0.20240420052153-909523c84ca2


### PR DESCRIPTION
Problem: the upstream scheduler-plugins is now using 1.22.0.
Solution: we should do the same.

## Other Changes:

- The webhook interface changing pointers to be proper interfaces (no longer builds with pointers)
- Boost system is no longer provided in the container or needed for bindings, will result in error if not removed
- Entrypoint changed again
- Build logic in hack/build-images.sh again changed - I decided to move the docker build commands into our Makefile to both simplify and prevent these future bugs. Most of them are just tweaks/changes to environment variables.