### PR TITLE
jgf: update edge metadata to include subsystem

### DIFF
--- a/src/fluence/jgf/jgf.go
+++ b/src/fluence/jgf/jgf.go
@@ -100,7 +100,7 @@ func (g *FluxJGF) MakeEdge(source string, target string, contains string) {
 		Source: source,
 		Target: target,
 		Metadata: edgeMetadata{
-			Name: map[string]string{containmentKey: contains},
+			Subsystem: containmentKey,
 		},
 	}
 	g.Graph.Edges = append(g.Graph.Edges, newedge)

--- a/src/fluence/jgf/types.go
+++ b/src/fluence/jgf/types.go
@@ -33,7 +33,7 @@ type edge struct {
 }
 
 type edgeMetadata struct {
-	Name map[string]string `json:"name,omitempty"`
+	Subsystem string `json:"subsystem,omitempty"`
 }
 
 type nodeMetadata struct {


### PR DESCRIPTION
Problem: flux-sched now requires the subsystem edge metadata.
Solution: remove previous name->containment, replace with this.