### PR TITLE
Bug: JGF Name was removed, and build with distroless destroyed logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,13 @@ prepare: clone
 	# These are entirely new directory structures
 	rm -rf $(CLONE_UPSTREAM)/pkg/fluence
 	rm -rf $(CLONE_UPSTREAM)/pkg/logger
+	rm -rf $(CLONE_UPSTREAM)/build/scheduler
 	# rm -rf $(CLONE_UPSTREAM)/cmd/app
 	rm -rf $(CLONE_UPSTREAM)/pkg/controllers/podgroup_controller.go
 	rm -rf $(CLONE_UPSTREAM)/cmd/controller/app/server.go
 	cp -R sig-scheduler-plugins/pkg/logger $(CLONE_UPSTREAM)/pkg/logger
 	cp -R sig-scheduler-plugins/pkg/fluence $(CLONE_UPSTREAM)/pkg/fluence
+	cp -R sig-scheduler-plugins/build/scheduler $(CLONE_UPSTREAM)/build/scheduler
 	cp -R sig-scheduler-plugins/pkg/controllers/* $(CLONE_UPSTREAM)/pkg/controllers/
 	# This is the one exception not from sig-scheduler-plugins because it is needed in both spots
 	cp -R src/fluence/fluxcli-grpc $(CLONE_UPSTREAM)/pkg/fluence/fluxcli-grpc

--- a/sig-scheduler-plugins/build/scheduler/Dockerfile
+++ b/sig-scheduler-plugins/build/scheduler/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG GO_BASE_IMAGE=golang
+ARG DISTROLESS_BASE_IMAGE=gcr.io/distroless/static:nonroot
+FROM --platform=${BUILDPLATFORM} $GO_BASE_IMAGE AS builder
+
+WORKDIR /workspace
+COPY . .
+ARG TARGETARCH
+RUN make build-scheduler GO_BUILD_ENV='CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH}' && \
+    cp /workspace/bin/kube-scheduler /bin/kube-scheduler
+
+# Disable distroless because we are wanting a filesystem to preserve logs, etc.
+FROM alpine:3.20
+# FROM --platform=${BUILDPLATFORM} $DISTROLESS_BASE_IMAGE
+
+WORKDIR /bin
+COPY --from=builder /workspace/bin/kube-scheduler .
+USER 65532:65532
+
+ENTRYPOINT ["/bin/kube-scheduler"]

--- a/src/fluence/go.mod
+++ b/src/fluence/go.mod
@@ -3,7 +3,7 @@ module github.com/flux-framework/flux-k8s/flux-plugin/fluence
 go 1.22
 
 require (
-	github.com/flux-framework/fluxion-go v0.32.1-0.20240420052153-909523c84ca2
+	github.com/flux-framework/fluxion-go v0.39.0
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.26.0

--- a/src/fluence/go.sum
+++ b/src/fluence/go.sum
@@ -98,8 +98,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flux-framework/fluxion-go v0.32.1-0.20240420052153-909523c84ca2 h1:Yz/vVX0XfB2q51ZLh2p8YI5vphvv0rZF4PqtKPscvsY=
-github.com/flux-framework/fluxion-go v0.32.1-0.20240420052153-909523c84ca2/go.mod h1:jA5+kOSLxchFzixzYEvMAGjkXB5yszO/HxUwdhX/5/U=
+github.com/flux-framework/fluxion-go v0.39.0 h1:f68CTxHouyOvjfgu5YKYFHQ405vxtdSlG8crPph8+DU=
+github.com/flux-framework/fluxion-go v0.39.0/go.mod h1:jA5+kOSLxchFzixzYEvMAGjkXB5yszO/HxUwdhX/5/U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/src/fluence/utils/utils.go
+++ b/src/fluence/utils/utils.go
@@ -258,7 +258,6 @@ func computeTotalRequests(podList *corev1.PodList) (total map[corev1.ResourceNam
 
 type allocation struct {
 	Type      string
-	Name      string
 	Basename  string
 	CoreCount int
 }
@@ -292,7 +291,6 @@ func ParseAllocResult(allocated, podName string) []allocation {
 		if metadata["type"].(string) == jgf.NodeType {
 			result = append(result, allocation{
 				Type:      metadata["type"].(string),
-				Name:      metadata["name"].(string),
 				Basename:  metadata["basename"].(string),
 				CoreCount: corecount,
 			})
@@ -303,9 +301,9 @@ func ParseAllocResult(allocated, podName string) []allocation {
 	}
 	fmt.Printf("Final node result for %s\n", podName)
 	for i, alloc := range result {
-		fmt.Printf("Node %d: %s\n", i, alloc.Name)
-		fmt.Printf("  Type: %s\n  Name: %s\n  Basename: %s\n  CoreCount: %d\n",
-			alloc.Type, alloc.Name, alloc.Basename, alloc.CoreCount)
+		fmt.Printf("Node %d: %s\n", i, alloc.Basename)
+		fmt.Printf("  Type: %s\n  Basename: %s\n  CoreCount: %d\n",
+			alloc.Type, alloc.Basename, alloc.CoreCount)
 
 	}
 	return result


### PR DESCRIPTION
There were a few problems here, and I tried to get at least 2 into separate commits.

- Issues resolves: https://github.com/flux-framework/flux-k8s/issues/80
- Build failure [from yesterday](https://github.com/flux-framework/flux-k8s/actions/runs/11197737249/job/31128174290) - silent but deadly! 

### Logging Not Working

The base image for the scheduler [used to use alpine](https://github.com/kubernetes-sigs/scheduler-plugins/blob/4a00cfd583d53118642925523bd0546bce76bb90/build/scheduler/Dockerfile#L25), which was a good strategy to have a minimal build (image size wise) and still have a filesystem. We used a filesystem to write logs to `/tmp/fluence.log`. So when this was changed to [the current distroless](https://github.com/kubernetes-sigs/scheduler-plugins/blob/bb56af11184a0f6ed33e2fc8b189a5b1ccfc60e4/build/scheduler/Dockerfile#L23), I basically saw no logging, and it's not clear if there were other errors being hidden beyond the initial startup in the entrypoint. I just saw nothing printed, anywhere, which made debugging hard, so I looked to the Dockerfile and found that. Then I was able to see the next layer of the error onion :onion: 

```console
I1006 21:44:23.452232       1 fluxion.go:91] [Fluence] There are no errors
	----Match Allocate output---
jobid: 1
reserved: false
allocated: {"graph": {"nodes": [{"id": "3", "metadata": {"type": "core", "id": 0, "rank": -1, "exclusive": true, "paths": {"containment": "/k8scluster0/0/kind-worker1/core0"}}}, {"id": "2", "metadata": {"type": "node", "basename": "kind-worker", "id": 1, "rank": -1, "paths": {"containment": "/k8scluster0/0/kind-worker1"}}}, {"id": "1", "metadata": {"type": "subnet", "basename": "", "id": 0, "rank": -1, "paths": {"containment": "/k8scluster0/0"}}}, {"id": "0", "metadata": {"type": "cluster", "basename": "k8scluster", "id": 0, "rank": -1, "paths": {"containment": "/k8scluster0"}}}], "edges": [{"source": "2", "target": "3"}, {"source": "1", "target": "2"}, {"source": "0", "target": "1"}]}}

at: 0
overhead: 0.000442
panic: interface conversion: interface {} is nil, not string

goroutine 52 [running]:
github.com/flux-framework/flux-k8s/flux-plugin/fluence/utils.ParseAllocResult({0xc00067e000, 0x2ad}, {0xc00063c300, 0x29})
	/go/src/fluence/utils/utils.go:295 +0x785
github.com/flux-framework/flux-k8s/flux-plugin/fluence/fluxion.(*Fluxion).Match(0xc0003a6ba0, {0x12b54a0?, 0xc000099ad8?}, 0xc0000c03c0)
	/go/src/fluence/fluxion/fluxion.go:110 +0x2a8
github.com/flux-framework/flux-k8s/flux-plugin/fluence/fluxcli-grpc._FluxcliService_Match_Handler({0x12b54a0, 0xc0003a6ba0}, {0x15f4e48, 0xc0001ea990}, 0xc00058e300, 0x0)
	/go/src/fluence/fluxcli-grpc/fluxcli_grpc.pb.go:95 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000481180, {0x15f9b98, 0xc000002000}, 0xc0005a2900, 0xc0001ea3c0, 0x1f17240, 0x0)
	/go/src/fluence/vendor/google.golang.org/grpc/server.go:1286 +0xc5e
google.golang.org/grpc.(*Server).handleStream(0xc000481180, {0x15f9b98, 0xc000002000}, 0xc0005a2900, 0x0)
	/go/src/fluence/vendor/google.golang.org/grpc/server.go:1609 +0x9da
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/go/src/fluence/vendor/google.golang.org/grpc/server.go:934 +0x8d
created by google.golang.org/grpc.(*Server).serveStreams.func1 in goroutine 51
	/go/src/fluence/vendor/google.golang.org/grpc/server.go:932 +0x226
```

Discussed next.

### Name removed

The interface conversion issue hinted at a change in flux, and looking at the data as presented (and what we expect to parse) it was quick to see. The "Name" field was [removed](https://github.com/flux-framework/flux-sched/tree/master/t/data/resource/jgfs) from the response from fluxion:

```console
jobid: 1
reserved: false
allocated: {"graph": {"nodes": [{"id": "3", "metadata": {"type": "core", "id": 0, "rank": -1, "exclusive": true, "paths": {"containment": "/k8scluster0/0/kind-worker1/core0"}}}, {"id": "2", "metadata": {"type": "node", "basename": "kind-worker", "id": 1, "rank": -1, "paths": {"containment": "/k8scluster0/0/kind-worker1"}}}, {"id": "1", "metadata": {"type": "subnet", "basename": "", "id": 0, "rank": -1, "paths": {"containment": "/k8scluster0/0"}}}, {"id": "0", "metadata": {"type": "cluster", "basename": "k8scluster", "id": 0, "rank": -1, "paths": {"containment": "/k8scluster0"}}}], "edges": [{"source": "2", "target": "3"}, {"source": "1", "target": "2"}, {"source": "0", "target": "1"}]}}
```
Note that basename is present in the above, but not name. This led to an interface conversion error, where nil was attempted to be converted to a string.

```console

at: 0
overhead: 0.000442
panic: interface conversion: interface {} is nil, not string

goroutine 52 [running]:
```

Notably, another piece of this was that the bindings for fluxion-go were pinned to 0.32.0, and yet we were cloning the latest flux-sched. This is why I updated the bindings version to the latest, which has nicely been releasing itself for quite some time now :) 

I'll ping for review when tests pass.