### PR TITLE
bug: context missing from EventsToRegister

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -145,8 +145,8 @@ jobs:
 
     - name: Install Cert Manager
       run: |
-        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.1/cert-manager.yaml
-        sleep 10
+        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
+        sleep 20
 
     - name: Test Fluence
       run: /bin/bash ./.github/test.sh

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We provide a set of pre-build containers [alongside the repository](https://gith
 that you can easily use to deploy Fluence right away! You'll first need to install the certificate manager:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.1/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
 ```
 
 And then clone the proper helm charts, and then install to your cluster. We provide helper commands to do that.
@@ -177,7 +177,7 @@ kind create cluster --config ./examples/kind-config.yaml
 And again install the certificate manager:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.1/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
 ```
 
 **Important** if you are developing or testing fluence, note that custom scheduler plugins don't seem to work out of the box with MiniKube (but everything works with kind). Likely there are extensions or similar that need to be configured with MiniKube (that we have not looked into).

--- a/sig-scheduler-plugins/pkg/fluence/fluence.go
+++ b/sig-scheduler-plugins/pkg/fluence/fluence.go
@@ -140,14 +140,15 @@ func (fluence *Fluence) Name() string {
 
 // Fluence has added delete, although I wonder if update includes that signal
 // and it's redundant?
-func (fluence *Fluence) EventsToRegister() []framework.ClusterEventWithHint {
+func (fluence *Fluence) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
 	// To register a custom event, follow the naming convention at:
-	// https://git.k8s.io/kubernetes/pkg/scheduler/eventhandlers.go#L403-L410
+	// https://github.com/kubernetes/kubernetes/pull/101394
+	// Please follow: eventhandlers.go#L403-L410
 	podGroupGVK := fmt.Sprintf("podgroups.v1alpha1.%v", scheduling.GroupName)
 	return []framework.ClusterEventWithHint{
 		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Add | framework.Delete}},
 		{Event: framework.ClusterEvent{Resource: framework.GVK(podGroupGVK), ActionType: framework.Add | framework.Update | framework.Delete}},
-	}
+	}, nil
 }
 
 // TODO we need to account for affinity here


### PR DESCRIPTION
Problem: the custom scheduler plugin interface now requires a context variable, and return of an array and error (which is empty/not used and nil) 
Solution: add context.Context for it, and the correct return signature.

Error:  https://github.com/flux-framework/flux-k8s/actions/runs/12217632429/job/34082138214

If there are other errors that resulted from updates (still hiding under this one) I'll follow up with fixes here.